### PR TITLE
docs: add VyOS provisioning to bootstrap process

### DIFF
--- a/docs/architecture/05_building_blocks/03_platform_cluster.md
+++ b/docs/architecture/05_building_blocks/03_platform_cluster.md
@@ -29,6 +29,19 @@ The Platform Cluster is a **3-node Talos** cluster with a hybrid physical/virtua
 - **UM760 (Physical)**: Survives Harvester failures. If Harvester is down, the Platform Cluster retains quorum (1 of 3) and can orchestrate recovery
 - **Harvester VMs**: Provide HA without requiring additional physical hardware
 
+### Bootstrap Sequence
+
+The platform cluster is built in **4 phases**:
+
+| Phase | Description | Nodes |
+|:---|:---|:---|
+| **1. Seed** | Temporary Talos VM on NAS runs Tinkerbell | 1 (NAS VM) |
+| **2. Single-Node Platform** | UM760 provisioned via PXE, workloads migrated | 1 (UM760) |
+| **3. Harvester Online** | MS-02 nodes provisioned with Harvester HCI | HCI ready |
+| **4. Full Platform** | CP-2 and CP-3 VMs created on Harvester | 3 (HA) |
+
+For detailed bootstrap procedures, see `bootstrap/genesis/` runbooks.
+
 ```
 ┌─────────────────────────────────────────────────────────────────┐
 │                      Platform Cluster                           │

--- a/docs/architecture/05_building_blocks/04_downstream_clusters.md
+++ b/docs/architecture/05_building_blocks/04_downstream_clusters.md
@@ -145,9 +145,10 @@ repo/
 ### Dynamic Discovery Pattern
 The Platform Cluster's Argo CD uses an `ApplicationSet` with a Git directory generator to automatically discover and deploy workloads:
 
-1. Creates the downstream cluster (CAPI resources)
-2. Installs Argo CD Agent on the downstream cluster
+1. Creates the downstream cluster (CAPI resources via TenantCluster XR)
+2. TenantCluster XR composition automatically creates an Argo CD cluster Secret with the new cluster's kubeconfig
 3. ApplicationSet scans the cluster-specific folder and creates `Application` resources for each workload
+4. Argo CD applies manifests directly to the downstream cluster using the kubeconfig (hub-and-spoke model)
 
 ## Integration with Platform Services
 

--- a/docs/architecture/08_concepts/argocd.md
+++ b/docs/architecture/08_concepts/argocd.md
@@ -1,0 +1,294 @@
+# 08. Concepts - Argo CD GitOps Engine
+
+## Overview
+**Argo CD** serves as the GitOps engine for the entire lab infrastructure. It runs as a single instance on the Platform Cluster and manages deployments across all clusters using a **Hub-and-Spoke** architecture.
+
+Its primary responsibility is to sync declarative configurations from Git to Kubernetes clusters, ensuring that the desired state matches the actual state. Argo CD syncs **Claims** (simplified YAML), and Crossplane handles the complex reconciliation.
+
+> [!IMPORTANT]
+> **Design Decision**: We use a single centralized Argo CD instance rather than distributed instances. This simplifies credentials, provides a unified dashboard, and leverages the fact that all clusters exist on the same lab network (See [Multi-Cluster Argo CD Strategy](../PROPOSED_STRUCTURE.md#multi-cluster-argo-cd-strategy)).
+
+---
+
+## Hub-and-Spoke Architecture
+
+The Platform Cluster runs the central Argo CD instance that manages all clusters, including itself.
+
+```
+┌───────────────────────────────────────────────────────────────┐
+│                      Platform Cluster                          │
+│  ┌──────────────────────────────────────────────────────────┐ │
+│  │                       Argo CD                             │ │
+│  │  ┌────────────────────────────────────────────────────┐  │ │
+│  │  │           Registered Cluster Secrets               │  │ │
+│  │  │  • in-cluster (platform)       [Manual]            │  │ │
+│  │  │  • harvester                   [Manual]            │  │ │
+│  │  │  • media   ←─────────────┐                         │  │ │
+│  │  │  • dev     ←─────────────┤ Created by TenantCluster│  │ │
+│  │  │  • prod    ←─────────────┘ XR (Automatic)          │  │ │
+│  │  └────────────────────────────────────────────────────┘  │ │
+│  └─────────────────────────┬────────────────────────────────┘ │
+└────────────────────────────┼──────────────────────────────────┘
+                             │ Apply manifests via kubeconfig
+         ┌───────────────────┼───────────────────┐
+         ▼                   ▼                   ▼
+    ┌─────────┐         ┌─────────┐         ┌─────────┐
+    │Harvester│         │  media  │         │   dev   │
+    │   HCI   │         │ (Tenant)│         │ (Tenant)│
+    └─────────┘         └─────────┘         └─────────┘
+```
+
+### Cluster Registration
+
+| Cluster Type | Registration Method | Managed By |
+|:---|:---|:---|
+| **Platform** | Manual Secret during bootstrap | Genesis scripts |
+| **Harvester** | Manual Secret after Harvester boots | Genesis runbook |
+| **Tenant** | Automatic via TenantCluster XR | Crossplane Composition |
+
+When a `TenantCluster` XR is created, the Crossplane composition automatically generates an Argo CD cluster Secret containing the CAPI-generated kubeconfig. This enables immediate discovery and deployment.
+
+---
+
+## ApplicationSet Strategy
+
+We use **two primary ApplicationSets** to manage all cluster resources:
+
+### 1. Cluster Definitions (`cluster-definitions`)
+
+Syncs the **root-level Claims** (`cluster.yaml`, `core.yaml`, `platform.yaml`) to the **Platform Cluster** where Crossplane processes them.
+
+| Field | Value | Notes |
+|:---|:---|:---|
+| **Generator** | Git (directories) | Matches `clusters/*` |
+| **Destination** | `https://kubernetes.default.svc` | Always platform (in-cluster) |
+| **Recurse** | `false` | Only root YAML files |
+| **Include** | `*.yaml` | Excludes subdirectories |
+
+```yaml
+# Syncs clusters/media/cluster.yaml → Platform Cluster
+# Crossplane then creates the actual Kubernetes cluster
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: cluster-definitions
+spec:
+  generators:
+    - git:
+        directories:
+          - path: clusters/*
+  template:
+    spec:
+      destination:
+        server: https://kubernetes.default.svc
+      source:
+        directory:
+          recurse: false
+          include: '*.yaml'
+```
+
+### 2. Cluster Apps (`cluster-apps`)
+
+Uses a **matrix generator** to deploy applications to their target clusters.
+
+| Generator | Purpose |
+|:---|:---|
+| **Clusters** | Discover registered Argo CD clusters via label selector |
+| **Git** | Find `apps/*` directories for each cluster |
+
+```yaml
+# Syncs clusters/media/apps/plex/ → Media Cluster
+# Syncs clusters/platform/apps/observability/ → Platform Cluster
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: cluster-apps
+spec:
+  generators:
+    - matrix:
+        generators:
+          - clusters:
+              selector:
+                matchExpressions:
+                  - key: lab.gilman.io/cluster-name
+                    operator: Exists
+          - git:
+              directories:
+                - path: 'clusters/{{name}}/apps/*'
+  template:
+    spec:
+      destination:
+        server: '{{server}}'  # Actual cluster endpoint from cluster Secret
+```
+
+This pattern ensures apps are deployed to the **correct cluster** (not always the platform).
+
+---
+
+## Sync Waves
+
+Argo CD supports **sync waves** to control the order of resource deployment within an Application.
+
+### Standard Wave Order
+
+| Wave | Resources | Purpose |
+|:---|:---|:---|
+| **0** | Namespaces, CRDs, XRDs | Foundation layer |
+| **1** | Crossplane Configurations | Install API definitions |
+| **2** | Core Services (XR Claims) | Base layer (Cilium, cert-manager) |
+| **3** | Platform Services (XR Claims) | Shared services (Zitadel, OpenBAO) |
+| **4** | Applications (XR Claims) | Tenant workloads |
+
+### Example Annotation
+
+```yaml
+apiVersion: lab.gilman.io/v1alpha1
+kind: CoreServices
+metadata:
+  name: platform
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"  # Deploy after XRDs
+spec:
+  version: "1.2.0"
+```
+
+> [!NOTE]
+> Sync waves are **relative** within a single Application. Use them to order resources that have dependencies (e.g., Namespace before Deployment).
+
+---
+
+## Integration with Crossplane
+
+Argo CD and Crossplane operate in a **division of labor**:
+
+| Layer | Responsibility | Tool |
+|:---|:---|:---|
+| **Sync** | Ensure Git → Cluster consistency | Argo CD |
+| **Composition** | Expand Claims → Low-level resources | Crossplane |
+| **Actuation** | Apply low-level resources | Kubernetes controllers (Helm, CAPI, etc.) |
+
+### Workflow Example
+
+```
+┌──────────────┐     ┌──────────────┐     ┌──────────────┐     ┌──────────────┐
+│  Git Commit  │────▶│  Argo CD     │────▶│  Crossplane  │────▶│   CAPI       │
+│              │     │  (Syncs)     │     │  (Composes)  │     │  (Actuates)  │
+│ cluster.yaml │     │              │     │              │     │              │
+│ (TenantCluster)    │ TenantCluster│     │ → Cluster    │     │ → Harvester  │
+│              │     │   XR Claim   │     │ → Machine    │     │   VMs        │
+└──────────────┘     └──────────────┘     └──────────────┘     └──────────────┘
+```
+
+1. Developer commits `clusters/media/cluster.yaml` (TenantCluster XR Claim)
+2. Argo CD detects change and syncs to Platform Cluster
+3. Crossplane sees the Claim and creates CAPI resources
+4. CAPI Harvester Provider provisions VMs on Harvester
+5. Cluster becomes ready; Crossplane creates Argo CD cluster Secret
+6. Argo CD automatically discovers new cluster and deploys apps
+
+---
+
+## Architecture Diagram
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│                           Git Repository                             │
+│  ┌────────────────────────────────────────────────────────────────┐ │
+│  │  clusters/                                                      │ │
+│  │  ├── platform/                                                  │ │
+│  │  │   ├── core.yaml         ← Crossplane, CAPI, cert-manager    │ │
+│  │  │   ├── platform.yaml     ← Zitadel, OpenBAO                  │ │
+│  │  │   └── apps/             ← Observability, Tinkerbell         │ │
+│  │  ├── harvester/                                                 │ │
+│  │  │   ├── config/           ← Networks, Images (Harvester CRDs) │ │
+│  │  │   └── vms/              ← CP-2, CP-3 VMs                     │ │
+│  │  ├── media/                                                     │ │
+│  │  │   ├── cluster.yaml      ← TenantCluster XR                  │ │
+│  │  │   ├── core.yaml         ← CoreServices XR                   │ │
+│  │  │   └── apps/             ← Plex, Jellyfin                    │ │
+│  │  └── dev/                                                       │ │
+│  │      ├── cluster.yaml                                           │ │
+│  │      └── apps/                                                  │ │
+│  └────────────────────────────────────────────────────────────────┘ │
+└─────────────────────────────┬────────────────────────────────────────┘
+                              │
+                              ▼
+          ┌───────────────────────────────────────────┐
+          │        Platform Cluster (Hub)             │
+          │  ┌─────────────────────────────────────┐  │
+          │  │          Argo CD                    │  │
+          │  │  ┌────────────────────────────────┐ │  │
+          │  │  │  ApplicationSets               │ │  │
+          │  │  │  • cluster-definitions         │ │  │
+          │  │  │  • cluster-apps                │ │  │
+          │  │  └────────────────────────────────┘ │  │
+          │  └─────────────────────────────────────┘  │
+          │                                            │
+          │  ┌─────────────────────────────────────┐  │
+          │  │         Crossplane                  │  │
+          │  │  • TenantCluster XRD                │  │
+          │  │  • CoreServices XRD                 │  │
+          │  │  • Application XRD                  │  │
+          │  └─────────────────────────────────────┘  │
+          └───────────────────────────────────────────┘
+                              │
+          ┌───────────────────┼───────────────────┐
+          ▼                   ▼                   ▼
+    ┌──────────┐        ┌──────────┐        ┌──────────┐
+    │Harvester │        │  media   │        │   dev    │
+    │Raw CRDs  │        │XR Claims │        │XR Claims │
+    └──────────┘        └──────────┘        └──────────┘
+```
+
+---
+
+## Access and Monitoring
+
+| Feature | Endpoint |
+|:---|:---|
+| **UI** | `https://argocd.lab.local` |
+| **CLI** | `argocd` (installed via package manager) |
+| **Authentication** | OIDC via Zitadel |
+| **RBAC** | Admin-only (single operator) |
+
+### Key Metrics (Prometheus)
+
+| Metric | Purpose |
+|:---|:---|
+| `argocd_app_sync_status` | Application sync state (Synced/OutOfSync) |
+| `argocd_app_health_status` | Application health (Healthy/Degraded) |
+| `argocd_app_sync_total` | Sync operation count |
+| `argocd_app_reconcile_count` | Reconciliation frequency |
+
+> [!TIP]
+> Use the Argo CD UI to visualize the dependency graph of Crossplane compositions. This helps debug XR expansion issues.
+
+---
+
+## Operational Notes
+
+### Manual vs Automatic Sync
+
+| Mode | When to Use |
+|:---|:---|
+| **Automatic** | Production clusters (platform, tenant apps) |
+| **Manual** | Bootstrap phase, risky changes |
+
+All production ApplicationSets use `syncPolicy.automated.selfHeal: true` to prevent configuration drift.
+
+### Secrets Management
+
+Argo CD does **not** manage secrets directly. Secrets are injected via:
+- **Vault Secrets Operator (VSO)**: Syncs secrets from OpenBAO into Kubernetes
+- **External Secrets Operator (ESO)**: Alternative to VSO (not currently used)
+
+### Disaster Recovery
+
+In a full platform rebuild:
+1. Restore etcd backup (contains Argo CD state)
+2. Argo CD Applications automatically re-sync from Git
+3. Crossplane reprocesses all XR Claims
+4. Clusters and apps return to desired state
+
+> [!IMPORTANT]
+> Git is the **source of truth**. Argo CD is stateless; all state lives in Git or Kubernetes etcd.

--- a/docs/architecture/08_concepts/harvester.md
+++ b/docs/architecture/08_concepts/harvester.md
@@ -1,0 +1,366 @@
+# 08. Concepts - Harvester HCI
+
+## Overview
+**Rancher Harvester** serves as the Hyper-Converged Infrastructure (HCI) layer for the lab, providing unified compute and storage capabilities. Unlike the Platform and Tenant clusters, Harvester is a **standalone Kubernetes cluster** managed via raw Harvester CRDs rather than Crossplane XRs.
+
+It acts as the virtualization foundation that enables CAPI to provision downstream clusters, while also hosting special-purpose VMs that fall outside the Kubernetes orchestration model.
+
+> [!NOTE]
+> Harvester is unique in the architecture: it is both a Kubernetes cluster itself AND the infrastructure layer that hosts other Kubernetes clusters (Platform VMs, Tenant VMs).
+
+---
+
+## Harvester as a Managed Cluster
+
+Harvester is registered with Argo CD as a managed cluster, but it differs from Platform and Tenant clusters in key ways:
+
+| Aspect | Harvester | Platform/Tenant Clusters |
+|:---|:---|:---|
+| **Purpose** | HCI layer (VMs, storage) | Workload orchestration |
+| **API Type** | Raw Harvester CRDs | Crossplane XRs |
+| **VMs Provisioned Via** | VirtualMachine CRDs | CAPI (TenantCluster XR) |
+| **Managed By** | Argo CD (direct) | Argo CD → Crossplane |
+| **Provisioned By** | Tinkerbell (PXE bare-metal) | CAPI + Harvester provider |
+
+### Registration Process
+
+During bootstrap (Phase 3), Harvester is manually registered with Argo CD:
+
+```yaml
+# Applied during genesis step 12
+apiVersion: v1
+kind: Secret
+metadata:
+  name: harvester
+  namespace: argocd
+  labels:
+    argocd.argoproj.io/secret-type: cluster
+    lab.gilman.io/cluster-name: harvester
+type: Opaque
+stringData:
+  name: harvester
+  server: https://harvester.lab.local:6443
+  config: |
+    {
+      "tlsClientConfig": {
+        "caData": "...",
+        "certData": "...",
+        "keyData": "..."
+      }
+    }
+```
+
+Once registered, Argo CD can sync resources to Harvester via the `cluster-apps` ApplicationSet.
+
+---
+
+## Architecture Position
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                    Physical Layer (Bare Metal)                   │
+│  ┌──────────────┐  ┌──────────────┐  ┌──────────────┐           │
+│  │   MS-02 #1   │  │   MS-02 #2   │  │   MS-02 #3   │           │
+│  │ i9-12900H    │  │ i9-12900H    │  │ i9-12900H    │           │
+│  │ 64GB RAM     │  │ 64GB RAM     │  │ 64GB RAM     │           │
+│  │ 2x NVMe SSD  │  │ 2x NVMe SSD  │  │ 2x NVMe SSD  │           │
+│  └──────┬───────┘  └──────┬───────┘  └──────┬───────┘           │
+└─────────┼──────────────────┼──────────────────┼──────────────────┘
+          │                  │                  │
+          │    ┌─────────────┴──────────┐       │
+          │    │    LACP Bond (20Gbps)  │       │
+          └────┼────────────────────────┼───────┘
+               │                        │
+          ┌────▼────────────────────────▼────┐
+          │      Harvester Cluster (HCI)     │
+          │  ┌────────────────────────────┐  │
+          │  │    RKE2 Kubernetes         │  │
+          │  │  ┌──────────┐ ┌──────────┐ │  │
+          │  │  │ KubeVirt │ │ Longhorn │ │  │
+          │  │  │   (VMs)  │ │ (Storage)│ │  │
+          │  │  └────┬─────┘ └──────────┘ │  │
+          │  └───────┼────────────────────┘  │
+          └──────────┼───────────────────────┘
+                     │
+     ┌───────────────┼───────────────────────────┐
+     │               │                           │
+     ▼               ▼                           ▼
+┌─────────┐    ┌──────────────┐         ┌────────────┐
+│Platform │    │Tenant Clusters│         │Standalone  │
+│VMs      │    │(CAPI-managed) │         │VMs         │
+│ CP-2    │    │ media, dev... │         │Gaming, NAS │
+│ CP-3    │    │               │         │            │
+└─────────┘    └───────────────┘         └────────────┘
+```
+
+---
+
+## Network Configuration
+
+Harvester uses **VLAN-aware networking** to provide native L2 connectivity to guest VMs.
+
+### VLAN Mapping
+
+| VLAN | Network Name | Subnet | Purpose | Harvester CRD |
+|:---|:---|:---|:---|:---|
+| **10** | `mgmt` | `10.10.10.0/24` | Harvester host management | `ClusterNetwork` |
+| **30** | `platform` | `10.10.30.0/24` | Platform Cluster VMs | `ClusterNetwork` |
+| **40** | `cluster` | `10.10.40.0/24` | Tenant Cluster VMs | `ClusterNetwork` |
+| **60** | `storage` | `10.10.60.0/24` | Longhorn replication (L2 only) | `ClusterNetwork` |
+
+### How VMs Connect
+
+VMs attach to these networks via Harvester's `VirtualMachineImage` and `VirtualMachine` resources:
+
+```yaml
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: cp-2
+  namespace: default
+spec:
+  template:
+    spec:
+      networks:
+        - name: platform
+          multus:
+            networkName: default/platform  # References ClusterNetwork
+```
+
+VMs receive IPs via:
+- **DHCP (VyOS)**: For Platform and Tenant VMs (VLANs 30/40)
+- **Static Assignment**: For special-purpose VMs (gaming, NAS)
+
+> [!IMPORTANT]
+> VLAN 60 (storage) is **non-routed**. It exists solely for Longhorn replication between Harvester nodes and is not accessible to VMs.
+
+---
+
+## VM Management
+
+Harvester hosts three categories of VMs:
+
+### 1. Platform Cluster VMs (Bootstrap Phase)
+
+Created during bootstrap (Phase 3) to expand the Platform Cluster from single-node (UM760) to 3-node HA.
+
+| VM | Purpose | Created Via | Lifecycle |
+|:---|:---|:---|:---|
+| **CP-2** | Platform control plane node 2 | Raw `VirtualMachine` CRD | Permanent |
+| **CP-3** | Platform control plane node 3 | Raw `VirtualMachine` CRD | Permanent |
+
+These VMs are defined in `clusters/harvester/vms/platform/` and synced by Argo CD.
+
+```yaml
+# clusters/harvester/vms/platform/cp-2.yaml
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: cp-2
+  namespace: default
+spec:
+  running: true
+  template:
+    spec:
+      domain:
+        cpu:
+          cores: 4
+        memory:
+          guest: 16Gi
+        devices:
+          disks:
+            - name: root
+              disk:
+                bus: virtio
+      volumes:
+        - name: root
+          persistentVolumeClaim:
+            claimName: cp-2-root
+      networks:
+        - name: platform
+          multus:
+            networkName: default/platform
+```
+
+> [!NOTE]
+> These VMs are created **before CAPI is available** (chicken-and-egg). Once the Platform Cluster is fully operational, CAPI takes over for Tenant Clusters.
+
+### 2. Tenant Cluster VMs (CAPI-Managed)
+
+Provisioned dynamically via the `TenantCluster` XR, which uses CAPI's Harvester provider.
+
+| Attribute | Value |
+|:---|:---|
+| **Created By** | CAPI `HarvesterMachine` resources |
+| **Lifecycle** | Ephemeral (destroyed when cluster is deleted) |
+| **Storage** | Longhorn-backed PVCs |
+| **Network** | VLAN 40 (`cluster` network) |
+
+These VMs **do NOT live in** `clusters/harvester/` — they are managed entirely by CAPI.
+
+```
+TenantCluster XR (clusters/media/cluster.yaml)
+  ↓
+CAPI Cluster + Machines
+  ↓
+HarvesterMachine resources
+  ↓
+VirtualMachine CRDs (created by CAPI provider)
+  ↓
+KubeVirt VMs on Harvester
+```
+
+### 3. Standalone VMs
+
+VMs for non-containerized workloads that do not fit the Kubernetes model.
+
+| Example | Use Case |
+|:---|:---|
+| **windows-gaming.yaml** | GPU passthrough gaming VM |
+| **truenas.yaml** | FreeBSD-based NAS appliance |
+| **vyos-test.yaml** | Router testing environment |
+
+These live in `clusters/harvester/vms/standalone/` and are managed like Platform VMs (raw CRDs).
+
+---
+
+## Storage
+
+Harvester provides two storage mechanisms:
+
+### Longhorn (Primary)
+
+| Feature | Value |
+|:---|:---|
+| **Backend** | NVMe SSDs in each MS-02 node |
+| **Replication** | 3 replicas (survives 1 node failure) |
+| **Network** | VLAN 60 (dedicated replication) |
+| **Use Cases** | VM root disks, PVCs for guest clusters |
+
+Longhorn is integrated with Harvester and managed automatically. Guest clusters access Longhorn via the **Harvester CSI Driver**.
+
+### NFS (Synology NAS)
+
+| Feature | Value |
+|:---|:---|
+| **Purpose** | VM image library, backups |
+| **Integration** | Mounted as external storage in Harvester UI |
+| **Performance** | Lower than Longhorn; suitable for cold data |
+
+Harvester can import VM images (e.g., Talos ISO) from NFS for faster deployments.
+
+> [!TIP]
+> VM backups target NFS, not Longhorn. This offloads backup I/O from the performance-critical NVMe pool.
+
+---
+
+## Integration with Platform
+
+Harvester integrates with the Platform Cluster in multiple ways:
+
+### 1. CAPI Infrastructure Provider
+
+The Platform Cluster runs the **CAPI Harvester Provider**, which:
+- Creates `VirtualMachine` resources on Harvester
+- Provisions Longhorn-backed PVCs for VM disks
+- Attaches VMs to the correct VLAN network
+
+### 2. Harvester Cloud Controller Manager (CCM)
+
+Guest clusters (Platform and Tenant) run the **Harvester CCM**, which provides:
+- **CSI Storage**: PersistentVolumes backed by Longhorn
+- **LoadBalancer**: ❌ **Not used** — Cilium BGP handles this (See [ADR 001](../09_design_decisions/001_use_bgp_loadbalancing.md))
+
+### 3. Bootstrap Dependency
+
+The Platform Cluster has a **bootstrapping dependency** on Harvester:
+
+```
+┌──────────────┐       ┌──────────────┐       ┌──────────────┐
+│  Phase 2:    │       │  Phase 3:    │       │  Phase 4:    │
+│  Single-Node │  ───▶ │  Harvester   │  ───▶ │  3-Node HA   │
+│  Platform    │       │  Provisioned │       │  Platform    │
+│  (UM760)     │       │  (MS-02s)    │       │  (+CP-2,CP-3)│
+└──────────────┘       └──────────────┘       └──────────────┘
+       │                      │                      ▲
+       │ Tinkerbell           │ Argo CD syncs        │
+       │ PXE boots            │ VirtualMachine CRDs  │
+       └──────────────────────┴──────────────────────┘
+```
+
+The Platform Cluster starts on bare-metal (UM760), provisions Harvester via Tinkerbell, then uses Harvester to create its own additional control plane nodes (CP-2, CP-3).
+
+---
+
+## What Lives in `clusters/harvester/`
+
+```
+clusters/harvester/
+├── config/
+│   ├── networks/
+│   │   ├── mgmt.yaml         # ClusterNetwork for VLAN 10
+│   │   ├── platform.yaml     # ClusterNetwork for VLAN 30
+│   │   ├── cluster.yaml      # ClusterNetwork for VLAN 40
+│   │   └── storage.yaml      # ClusterNetwork for VLAN 60
+│   └── images/
+│       └── talos-1.9.yaml    # VirtualMachineImage (Talos ISO)
+└── vms/
+    ├── platform/
+    │   ├── cp-2.yaml         # Platform control plane VM
+    │   └── cp-3.yaml         # Platform control plane VM
+    └── standalone/
+        └── .gitkeep          # (gaming, NAS VMs when created)
+```
+
+### Why Raw CRDs?
+
+Harvester has its own native API (`kubevirt.io`, `harvesterhci.io`). We use raw CRDs because:
+1. **No abstraction needed**: Harvester's API is already high-level
+2. **CAPI handles tenant VMs**: No need for Crossplane XRs
+3. **Simplicity**: Direct CRD management is clearer than XR indirection
+
+---
+
+## Operational Notes
+
+### Maintenance
+
+| Task | Procedure |
+|:---|:---|
+| **Node Drain** | Harvester live-migrates VMs automatically |
+| **Upgrades** | Performed via Harvester UI, rolling upgrade |
+| **Backups** | Harvester VM backups → NFS (Synology NAS) |
+
+### Access
+
+| Interface | URL | Auth |
+|:---|:---|:---|
+| **Harvester UI** | `https://harvester.lab.local` | Local admin credentials |
+| **Kubernetes API** | `https://harvester.lab.local:6443` | Kubeconfig (used by CAPI) |
+
+### Monitoring
+
+Harvester metrics are scraped by the Platform Cluster's Prometheus:
+
+| Metric | Purpose |
+|:---|:---|
+| `harvester_vm_status` | VM running/stopped state |
+| `longhorn_volume_actual_size_bytes` | Storage usage per volume |
+| `longhorn_node_status` | Longhorn node health |
+| `kubevirt_vmi_phase_count` | VM lifecycle phases |
+
+> [!IMPORTANT]
+> Harvester is a **critical dependency**. If Harvester is down, Tenant Clusters cannot be provisioned, but existing VMs continue to run (KubeVirt failover).
+
+---
+
+## Disaster Recovery
+
+In a Harvester failure scenario:
+
+1. **Single Node Failure**: VMs live-migrate to surviving nodes, Longhorn replicates data
+2. **Quorum Loss**: Harvester becomes read-only; manual intervention required
+3. **Full Rebuild**: Reprovision Harvester via Tinkerbell, restore VM definitions from Git
+
+> [!TIP]
+> `clusters/harvester/` is version-controlled. All VM definitions can be reapplied via Argo CD after Harvester is restored.

--- a/docs/architecture/09_design_decisions/004_argocd_hub_spoke.md
+++ b/docs/architecture/09_design_decisions/004_argocd_hub_spoke.md
@@ -1,0 +1,60 @@
+# ADR 004: Argo CD Hub-and-Spoke Strategy
+
+**Status**: Accepted
+**Date**: 2025-12-19
+
+## Context
+The lab architecture includes multiple Kubernetes clusters that need declarative management:
+*   **Platform Cluster**: Hosts shared services (Crossplane, CAPI, Argo CD, identity, observability)
+*   **Harvester Cluster**: HCI layer for VM management and storage
+*   **Tenant Clusters**: Application workload clusters (media, dev, prod)
+
+We need a multi-cluster GitOps strategy that enables centralized management while maintaining simplicity for a single-administrator homelab environment.
+
+## Options
+
+### Option A: Hub-and-Spoke (Direct Apply)
+A single Argo CD instance on the platform cluster directly manages all clusters using kubeconfig-based cluster Secrets.
+*   **Mechanism**: Argo CD maintains cluster Secrets for each managed cluster. Applications sync directly to target clusters via kubeconfig credentials.
+*   **Pros**:
+    *   **Single pane of glass**: One Argo CD UI for all clusters.
+    *   **Simple architecture**: No additional components or agents.
+    *   **Network accessibility**: All clusters on same lab network with direct connectivity.
+    *   **CAPI integration**: CAPI already generates kubeconfigs for tenant clusters.
+    *   **Mature pattern**: Well-documented, battle-tested approach.
+*   **Cons**:
+    *   **Credential management**: Hub must store and rotate cluster credentials.
+    *   **Hub as single point of failure**: If platform cluster fails, no cluster management.
+
+### Option B: Agent per Cluster (Pull Model)
+Deploy Argo CD ApplicationSet Controller or Argo CD Agent on each managed cluster to pull configurations.
+*   **Mechanism**: Each cluster runs an agent that pulls from Git and applies locally.
+*   **Pros**:
+    *   **Reduced hub privileges**: Hub doesn't need cluster admin credentials.
+    *   **Works across NAT/firewalls**: Pull model doesn't require inbound connectivity.
+*   **Cons**:
+    *   **Complexity**: Additional component on every cluster.
+    *   **Fragmented visibility**: Harder to get unified view of all clusters.
+    *   **Unnecessary for lab**: No NAT/firewall restrictions in homelab network.
+
+### Option C: Federated (Separate Instances)
+Run independent Argo CD instances on each cluster managing only themselves.
+*   **Mechanism**: Each cluster has its own Argo CD managing its own resources.
+*   **Pros**:
+    *   **Full isolation**: Cluster failures don't affect others.
+    *   **No credential sharing**: Each Argo CD uses in-cluster access.
+*   **Cons**:
+    *   **Operational overhead**: Multiple Argo CD instances to maintain.
+    *   **No centralized view**: Must access each cluster separately.
+    *   **Redundant for lab**: Overkill for single-administrator environment.
+
+## Decision
+**Use Option A: Hub-and-Spoke.**
+
+## Rationale
+1.  **Simplicity**: Single Argo CD instance provides unified management interface aligned with homelab operational model.
+2.  **Network Topology**: All clusters on flat lab network (VLANs with routing) with no NAT or firewall restrictions.
+3.  **CAPI Integration**: TenantCluster XR composition already generates kubeconfigs; automatically creating Argo CD cluster Secrets leverages existing infrastructure.
+4.  **Automatic Registration**: Crossplane compositions create Argo CD cluster Secrets when tenant clusters are provisioned, enabling zero-touch cluster onboarding.
+5.  **Bus Factor**: Single administrator makes distributed model unnecessary; centralized management reduces complexity.
+6.  **Maturity**: Hub-and-spoke is the most widely deployed pattern with extensive documentation and tooling support.

--- a/docs/architecture/09_design_decisions/005_seed_bootstrap_strategy.md
+++ b/docs/architecture/09_design_decisions/005_seed_bootstrap_strategy.md
@@ -1,0 +1,61 @@
+# ADR 005: Seed Bootstrap Strategy
+
+**Status**: Accepted
+**Date**: 2025-12-19
+
+## Context
+The platform cluster hosts Crossplane, which processes Composite Resource (XR) Claims to provision infrastructure. This creates a chicken-and-egg problem: the platform cluster must bootstrap itself, but it cannot use Crossplane XRs during initial bootstrap because Crossplane isn't running yet.
+
+Additionally, the seed cluster runs on a Synology NAS with limited resources (32GB RAM shared with DSM), making it unsuitable for running the full platform stack (Crossplane, CoreServices, Istio).
+
+The platform cluster's first node (UM760 bare-metal) must be provisioned via PXE using Tinkerbell, which itself needs to be running somewhere during bootstrap.
+
+## Options
+
+### Option A: Full Platform on Seed
+Run the complete platform stack (Crossplane, CoreServices, Tinkerbell) on the seed cluster, then migrate everything to the UM760.
+*   **Mechanism**: Deploy all platform services on NAS, provision UM760, then migrate workloads.
+*   **Pros**:
+    *   **Uniform deployment**: Use XRs from the start.
+    *   **Full GitOps**: No special-case manifests.
+*   **Cons**:
+    *   **Resource constraints**: NAS lacks RAM for Crossplane + Istio + CoreServices.
+    *   **Migration complexity**: Live-migrating stateful Crossplane resources is risky.
+    *   **Unnecessary overhead**: Full platform not needed just to PXE boot one node.
+
+### Option B: Minimal Seed with Raw Manifests
+Run only Tinkerbell on the seed cluster using raw Kubernetes manifests (not Crossplane XRs).
+*   **Mechanism**: Deploy Tinkerbell via temporary Argo CD Application pointing to `bootstrap/seed/` containing raw CRDs. After UM760 joins, delete bootstrap Application and redeploy Tinkerbell via XRDs on the platform cluster.
+*   **Pros**:
+    *   **Minimal footprint**: Only Tinkerbell services on NAS.
+    *   **Avoids chicken-and-egg**: Raw manifests don't require Crossplane.
+    *   **Clean migration**: Delete bootstrap Application, apply platform configuration.
+    *   **Resource-efficient**: Stays within NAS RAM constraints.
+*   **Cons**:
+    *   **Temporary divergence**: Seed configuration differs from steady-state.
+    *   **Manual transition**: Requires deleting bootstrap Application.
+
+### Option C: External Bootstrap Cluster
+Use an external VM or container runtime (e.g., kind, k3s) for temporary Tinkerbell deployment.
+*   **Mechanism**: Run Tinkerbell on disposable cluster outside the NAS.
+*   **Pros**:
+    *   **No seed cluster**: Avoids NAS resource usage entirely.
+    *   **Clean separation**: Bootstrap infrastructure is ephemeral.
+*   **Cons**:
+    *   **Additional dependency**: Requires external VM or Docker environment.
+    *   **Network complexity**: Must route PXE traffic to external cluster.
+    *   **Disposable infrastructure**: Harder to debug or recover if issues arise.
+
+## Decision
+**Use Option B: Minimal Seed with Raw Manifests.**
+
+## Rationale
+1.  **Resource Constraints**: NAS has only 32GB RAM shared with Synology DSM; running Tinkerbell-only keeps memory usage minimal.
+2.  **Avoids Chicken-and-Egg**: Raw Kubernetes manifests in `bootstrap/seed/` deploy Tinkerbell without requiring Crossplane.
+3.  **Clean Migration Path**: After UM760 joins the platform cluster:
+    *   Delete the temporary `bootstrap` Application
+    *   Deploy full platform configuration via XRs in `clusters/platform/`
+    *   Tinkerbell is redeployed via proper XRD-based path as `clusters/platform/apps/tinkerbell/`
+4.  **Simplicity**: Seed runs a single, well-defined service (Tinkerbell) with minimal dependencies.
+5.  **Debuggability**: Seed cluster remains accessible during bootstrap for troubleshooting.
+6.  **Alignment with Design Principles**: Once platform is operational, all infrastructure is managed via Crossplane XRs (steady state).

--- a/docs/architecture/09_design_decisions/006_harvester_managed_cluster.md
+++ b/docs/architecture/09_design_decisions/006_harvester_managed_cluster.md
@@ -1,0 +1,62 @@
+# ADR 006: Harvester as Managed Cluster
+
+**Status**: Accepted
+**Date**: 2025-12-19
+
+## Context
+Harvester is a bare-metal Kubernetes-based HCI (Hyper-Converged Infrastructure) platform that provides VM management, storage, and networking. It runs on dedicated hardware (MS-02 nodes) and is provisioned via Tinkerbell PXE boot.
+
+Harvester requires configuration for:
+*   **Networks**: VLANs for management, platform, tenant clusters, and storage replication
+*   **Images**: VM templates (e.g., Talos Linux images)
+*   **VMs**: Platform cluster control plane nodes (CP-2, CP-3) and standalone VMs (non-containerized workloads)
+
+We need a strategy for managing Harvester configuration declaratively and integrating it into the GitOps workflow.
+
+## Options
+
+### Option A: Manual Configuration
+Configure Harvester through its web UI or CLI.
+*   **Mechanism**: Manually create networks, images, and VMs via Harvester UI.
+*   **Pros**:
+    *   **Simplicity**: No additional tooling or configuration.
+    *   **Immediate**: Changes apply instantly.
+*   **Cons**:
+    *   **Not declarative**: Configuration drift, no GitOps benefits.
+    *   **No audit trail**: Changes not tracked in version control.
+    *   **Error-prone**: Manual operations increase risk of misconfiguration.
+
+### Option B: Separate Tooling (Terraform/Ansible)
+Use infrastructure-as-code tools (Terraform with Harvester provider, Ansible) to manage Harvester.
+*   **Mechanism**: Define Harvester resources in Terraform/Ansible, apply separately from Kubernetes clusters.
+*   **Pros**:
+    *   **Declarative**: Infrastructure as code with state management.
+    *   **Mature tooling**: Terraform Harvester provider exists.
+*   **Cons**:
+    *   **Fragmented workflow**: Separate tool from Argo CD/Kubernetes management.
+    *   **No unified visibility**: Harvester config not visible in Argo CD.
+    *   **Additional state management**: Terraform state requires separate backend.
+
+### Option C: Register Harvester with Argo CD
+Register Harvester as a managed cluster in Argo CD, syncing raw Harvester CRDs from Git.
+*   **Mechanism**: Create Argo CD cluster Secret with Harvester kubeconfig. Store Harvester resources (ClusterNetwork, VirtualMachineImage, VirtualMachine CRDs) in `clusters/harvester/`. Argo CD syncs directly to Harvester API.
+*   **Pros**:
+    *   **GitOps consistency**: Harvester config managed via Git like all other clusters.
+    *   **Unified visibility**: All infrastructure visible in Argo CD UI.
+    *   **Declarative VM management**: Platform CP-2/CP-3 VMs defined as code.
+    *   **Leverages existing tooling**: No new tools; uses Argo CD hub-and-spoke.
+*   **Cons**:
+    *   **Raw CRDs (not XRs)**: Harvester has its own API; cannot use Crossplane abstractions.
+    *   **Manual registration**: Harvester cluster Secret must be created manually (Harvester isn't provisioned via CAPI).
+
+## Decision
+**Use Option C: Register Harvester as Managed Cluster.**
+
+## Rationale
+1.  **GitOps Consistency**: Aligns with platform's GitOps-first design principle; all infrastructure configuration lives in Git.
+2.  **Declarative VM Management**: Platform cluster bootstrap VMs (CP-2, CP-3) are defined as VirtualMachine CRDs in `clusters/harvester/vms/platform/`, ensuring reproducible cluster expansion.
+3.  **Unified Tooling**: Leverages existing Argo CD hub-and-spoke model; no additional tools (Terraform/Ansible) required.
+4.  **Audit Trail**: All Harvester configuration changes tracked via Git commits with full history.
+5.  **Standalone VM Support**: Non-containerized workloads (gaming VMs, NAS VMs) can be managed declaratively in `clusters/harvester/vms/standalone/`.
+6.  **Bootstrap Integration**: During platform bootstrap (phase 3), Harvester cluster Secret is created manually, enabling Argo CD to immediately sync network/image/VM configuration.
+7.  **Network Configuration**: VLAN configs (mgmt, platform, cluster, storage) are versioned and applied declaratively, preventing configuration drift.

--- a/docs/architecture/appendices/A_repository_structure.md
+++ b/docs/architecture/appendices/A_repository_structure.md
@@ -1,0 +1,814 @@
+# Appendix A: Repository Structure Reference
+
+> **Status**: Authoritative Reference
+> **Date**: 2025-12-19
+
+This document defines the canonical directory structure for the lab monorepo. All code, configuration, and documentation must follow this structure.
+
+---
+
+## Table of Contents
+
+1. [Complete Directory Tree](#complete-directory-tree)
+2. [Top-Level Directory Overview](#top-level-directory-overview)
+3. [clusters/ - Argo CD Managed Clusters](#clusters---argo-cd-managed-clusters)
+4. [packages/ - Crossplane Configuration Packages](#packages---crossplane-configuration-packages)
+5. [infrastructure/ - Pre-Kubernetes Configuration](#infrastructure---pre-kubernetes-configuration)
+6. [bootstrap/ - Bootstrap and Recovery](#bootstrap---bootstrap-and-recovery)
+7. [Management Summary](#management-summary)
+8. [Naming Conventions](#naming-conventions)
+
+---
+
+## Complete Directory Tree
+
+```
+lab/
+│
+├── .github/
+│   └── workflows/
+│       ├── crossplane-build.yml          # Build Crossplane packages on tag
+│       ├── vyos-validate.yml             # PR validation for VyOS
+│       └── vyos-deploy.yml               # Deploy VyOS on merge
+│
+├── docs/
+│   └── architecture/                     # arc42 documentation
+│
+├── infrastructure/                       # NOT Argo CD managed
+│   │                                     # Pre-K8s / out-of-band configuration
+│   │
+│   ├── network/
+│   │   └── vyos/
+│   │       ├── configs/
+│   │       │   └── gateway.conf
+│   │       ├── packer/
+│   │       │   ├── vyos.pkr.hcl              # Packer template for VyOS image
+│   │       │   ├── variables.pkr.hcl         # Packer variables
+│   │       │   ├── http/
+│   │       │   │   └── preseed.cfg           # VyOS preseed configuration
+│   │       │   └── scripts/
+│   │       │       └── provision.sh          # Post-install provisioning script
+│   │       └── ansible/
+│   │           ├── playbooks/
+│   │           │   └── deploy.yml
+│   │           └── inventory/
+│   │               └── hosts.yml
+│   │
+│   ├── compute/
+│   │   └── talos/
+│   │       │                             # talhelper-managed Talos configs
+│   │       │                             # For platform cluster (bare-metal/PXE)
+│   │       │
+│   │       ├── talconfig.yaml            # talhelper configuration
+│   │       ├── talsecret.sops.yaml       # Encrypted Talos secrets
+│   │       ├── clusterconfig/            # Generated machine configs (gitignored)
+│   │       │   └── .gitkeep
+│   │       └── patches/                  # Machine config patches
+│   │           ├── common.yaml
+│   │           ├── controlplane.yaml
+│   │           └── worker.yaml
+│   │
+│   └── provisioning/
+│       └── tinkerbell/
+│           │                             # Tinkerbell workflow definitions
+│           │                             # (Templates, not instances — instances are XRs)
+│           │
+│           └── templates/
+│               ├── harvester-install.yaml
+│               └── talos-install.yaml
+│
+├── packages/                             # Crossplane Configuration Packages
+│   │                                     # Built as OCI → ghcr.io/gilmanlab/xrp-*
+│   │
+│   ├── infrastructure/                   # Tag: infrastructure/vX.Y.Z
+│   │   ├── crossplane.yaml
+│   │   ├── apis/
+│   │   │   ├── tenant-cluster/
+│   │   │   │   ├── definition.yaml       # TenantCluster XRD
+│   │   │   │   └── composition.yaml
+│   │   │   ├── hardware/
+│   │   │   │   ├── definition.yaml       # Hardware XRD (Tinkerbell)
+│   │   │   │   └── composition.yaml
+│   │   │   └── workflow/
+│   │   │       ├── definition.yaml       # Workflow XRD (Tinkerbell)
+│   │   │       └── composition.yaml
+│   │   └── functions/
+│   │       └── ...
+│   │
+│   └── platform/                         # Tag: platform/vX.Y.Z
+│       ├── crossplane.yaml
+│       ├── apis/
+│       │   ├── core-services/
+│       │   │   ├── definition.yaml       # CoreServices XRD (base layer)
+│       │   │   └── composition.yaml
+│       │   ├── platform-services/
+│       │   │   ├── definition.yaml       # PlatformServices XRD (shared services)
+│       │   │   └── composition.yaml
+│       │   ├── application/
+│       │   │   ├── definition.yaml       # Application XRD
+│       │   │   └── composition.yaml
+│       │   └── database/
+│       │       ├── definition.yaml       # Database XRD (CloudNativePG)
+│       │       └── composition.yaml
+│       └── functions/
+│           └── ...
+│
+├── clusters/                             # ALL Clusters - Argo CD managed
+│   │                                     # Discovered by ApplicationSet: clusters/*/
+│   │
+│   ├── platform/                         # Platform Cluster
+│   │   │                                 # Special: No cluster.yaml (bare-metal bootstrap)
+│   │   │
+│   │   ├── core.yaml                     # CoreServices XR (Crossplane, CAPI, cert-manager, etc.)
+│   │   ├── platform.yaml                 # PlatformServices XR (Zitadel, OpenBAO, etc.)
+│   │   └── apps/
+│   │       ├── tinkerbell/
+│   │       │   ├── hardware/
+│   │       │   │   ├── ms02-node1.yaml   # Hardware XR
+│   │       │   │   ├── ms02-node2.yaml
+│   │       │   │   ├── ms02-node3.yaml
+│   │       │   │   └── um760.yaml
+│   │       │   └── workflows/
+│   │       │       ├── harvester.yaml    # Workflow XR
+│   │       │       └── talos.yaml
+│   │       ├── observability/
+│   │       │   ├── prometheus.yaml       # Application XR
+│   │       │   ├── grafana.yaml
+│   │       │   └── loki.yaml
+│   │       └── capi/
+│   │           ├── providers.yaml        # CAPI provider configs
+│   │           └── harvester-config.yaml
+│   │
+│   ├── harvester/                        # Harvester HCI Cluster
+│   │   │                                 # Raw Harvester CRDs (NOT Crossplane XRs)
+│   │   │                                 # Registered with Argo CD after Harvester boots
+│   │   │
+│   │   ├── config/                       # Harvester configuration
+│   │   │   ├── networks/
+│   │   │   │   ├── mgmt.yaml             # VLAN 10 - Management
+│   │   │   │   ├── platform.yaml         # VLAN 30 - Platform cluster
+│   │   │   │   ├── cluster.yaml          # VLAN 40 - Tenant clusters
+│   │   │   │   └── storage.yaml          # VLAN 60 - Storage replication
+│   │   │   └── images/
+│   │   │       └── talos-1.9.yaml        # Talos VM image template
+│   │   │
+│   │   └── vms/                          # Virtual Machines
+│   │       ├── platform/                 # Platform cluster VMs (bootstrap)
+│   │       │   ├── cp-2.yaml             # Platform control plane node 2
+│   │       │   └── cp-3.yaml             # Platform control plane node 3
+│   │       └── standalone/               # Non-container workloads
+│   │           └── .gitkeep              # (windows-gaming.yaml, truenas.yaml, etc.)
+│   │
+│   ├── media/                            # Tenant Cluster
+│   │   ├── cluster.yaml                  # TenantCluster XR
+│   │   ├── core.yaml                     # CoreServices XR
+│   │   └── apps/
+│   │       ├── plex/
+│   │       │   └── plex.yaml             # Application XR
+│   │       ├── jellyfin/
+│   │       │   └── jellyfin.yaml
+│   │       └── arr-stack/
+│   │           └── arr-stack.yaml
+│   │
+│   ├── dev/                              # Tenant Cluster
+│   │   ├── cluster.yaml
+│   │   ├── core.yaml
+│   │   └── apps/
+│   │       ├── gitea/
+│   │       │   └── gitea.yaml
+│   │       └── runners/
+│   │           └── runners.yaml
+│   │
+│   └── prod/                             # Tenant Cluster
+│       ├── cluster.yaml
+│       ├── core.yaml
+│       └── apps/
+│           └── ...
+│
+└── bootstrap/
+    │
+    ├── seed/                             # One-time bootstrap manifests (raw K8s, NOT XRs)
+    │   │                                 # Deployed via temporary Argo CD Application
+    │   │
+    │   ├── tinkerbell/                   # Tinkerbell deployment (Helm or raw)
+    │   │   ├── namespace.yaml
+    │   │   └── release.yaml              # HelmRelease or raw manifests
+    │   │
+    │   ├── hardware/                     # Hardware definitions for bootstrap
+    │   │   ├── vp6630.yaml               # Raw Tinkerbell Hardware CRD (VyOS router)
+    │   │   └── um760.yaml                # Raw Tinkerbell Hardware CRD (platform node)
+    │   │
+    │   ├── workflows/                    # Provisioning workflows for bootstrap
+    │   │   ├── vp6630-vyos.yaml          # Raw Tinkerbell Workflow CRD (VyOS install)
+    │   │   └── um760-talos.yaml          # Raw Tinkerbell Workflow CRD (Talos install)
+    │   │
+    │   └── config-server/                # HTTP server for Talos configs
+    │       └── nginx.yaml                # Serves talhelper-generated configs
+    │
+    ├── genesis/                          # Runbooks and scripts
+    │   ├── README.md                     # Overview and prerequisites
+    │   ├── 01-build-vyos-image.md        # Build VyOS image with Packer
+    │   ├── 02-seed-cluster.md            # Create Talos VM on NAS
+    │   ├── 03-deploy-argocd.md           # Manual Argo CD install
+    │   ├── 04-apply-bootstrap.md         # Apply bootstrap Application
+    │   ├── 05-vyos-provisioning.md       # Wait for VyOS to PXE boot
+    │   ├── 06-um760-provisioning.md      # Wait for UM760 to PXE boot
+    │   ├── 07-migrate-to-um760.md        # Drain NAS, migrate to UM760
+    │   ├── 08-deploy-platform.md         # Delete bootstrap, apply full platform
+    │   ├── 09-provision-harvester.md     # Tinkerbell provisions MS-02s
+    │   ├── 10-expand-platform.md         # Add CP-2, CP-3 VMs
+    │   └── scripts/
+    │       ├── build-vyos-image.sh       # Runs Packer to build VyOS image
+    │       ├── generate-talos-config.sh  # Runs talhelper
+    │       ├── create-seed-vm.sh         # Creates Talos VM on NAS
+    │       └── install-argocd.sh         # Helm install Argo CD
+    │
+    └── recovery/
+        ├── etcd-restore.md
+        ├── platform-rebuild.md
+        └── scripts/
+            └── restore-etcd.sh
+```
+
+---
+
+## Top-Level Directory Overview
+
+| Directory | Purpose | Managed By | Git Tracked |
+|:----------|:--------|:-----------|:------------|
+| `.github/` | CI/CD workflows for building packages and deploying VyOS | GitHub Actions | Yes |
+| `docs/` | arc42 architecture documentation | Manual | Yes |
+| `infrastructure/` | Pre-Kubernetes and out-of-band configuration | Manual, Ansible | Yes |
+| `packages/` | Crossplane Configuration Packages (OCI artifacts) | Built by CI/CD | Yes (source) |
+| `clusters/` | Cluster definitions and application deployments | Argo CD | Yes |
+| `bootstrap/` | Bootstrap manifests, runbooks, and recovery procedures | Manual (one-time) | Yes |
+
+---
+
+## clusters/ - Argo CD Managed Clusters
+
+The `clusters/` directory contains all Kubernetes cluster configurations. Each subdirectory represents a cluster and is automatically discovered by Argo CD ApplicationSets.
+
+### Directory Pattern
+
+```
+clusters/
+├── <cluster-name>/
+│   ├── cluster.yaml      # TenantCluster XR (optional, not for platform)
+│   ├── core.yaml         # CoreServices XR (optional)
+│   ├── platform.yaml     # PlatformServices XR (optional, platform only)
+│   ├── config/           # Raw cluster configuration (Harvester only)
+│   ├── vms/              # VirtualMachine CRDs (Harvester only)
+│   └── apps/             # Application deployments
+│       └── <app-name>/
+│           └── *.yaml
+```
+
+### Cluster Types
+
+| Cluster Type | cluster.yaml | core.yaml | platform.yaml | config/ | vms/ | apps/ |
+|:-------------|:------------:|:---------:|:-------------:|:-------:|:----:|:-----:|
+| **Platform** | N/A | Required | Required | N/A | N/A | Required |
+| **Harvester** | N/A | N/A | N/A | Required | Required | N/A |
+| **Tenant** | Required | Required | N/A | N/A | N/A | Required |
+
+### Platform Cluster (`clusters/platform/`)
+
+The platform cluster is the control plane for the entire lab infrastructure. It hosts Crossplane, Argo CD, CAPI, and shared services.
+
+**Key Characteristics:**
+- No `cluster.yaml` - bootstrapped via bare-metal PXE (Tinkerbell + talhelper)
+- Hybrid deployment: UM760 (bare-metal) + CP-2/CP-3 (Harvester VMs)
+- Contains XR Claims for CoreServices and PlatformServices
+- Applications deployed via `apps/` subdirectories
+
+**File Structure:**
+
+```
+clusters/platform/
+├── core.yaml                           # CoreServices XR
+│                                       # - Crossplane
+│                                       # - CAPI (Cluster API)
+│                                       # - cert-manager
+│                                       # - external-dns
+│                                       # - Istio
+│
+├── platform.yaml                       # PlatformServices XR
+│                                       # - Zitadel (identity)
+│                                       # - OpenBAO (secrets)
+│                                       # - Vault Secrets Operator
+│
+└── apps/
+    ├── tinkerbell/
+    │   ├── hardware/
+    │   │   ├── ms02-node1.yaml         # Hardware XR for Harvester node 1
+    │   │   ├── ms02-node2.yaml         # Hardware XR for Harvester node 2
+    │   │   ├── ms02-node3.yaml         # Hardware XR for Harvester node 3
+    │   │   └── um760.yaml              # Hardware XR for platform node 1
+    │   └── workflows/
+    │       ├── harvester.yaml          # Workflow XR for Harvester installation
+    │       └── talos.yaml              # Workflow XR for Talos installation
+    │
+    ├── observability/
+    │   ├── prometheus.yaml             # Application XR
+    │   ├── grafana.yaml                # Application XR
+    │   └── loki.yaml                   # Application XR
+    │
+    └── capi/
+        ├── providers.yaml              # CAPI provider configurations
+        └── harvester-config.yaml       # Harvester provider setup
+```
+
+**Why No `cluster.yaml`?**
+
+The platform cluster cannot use the TenantCluster XR because that XR requires Crossplane and CAPI to already be running. The platform must be bootstrapped via PXE using Tinkerbell and talhelper. See [Appendix B: Bootstrap Procedure](B_bootstrap_procedure.md) for details.
+
+### Harvester Cluster (`clusters/harvester/`)
+
+Harvester is a hyperconverged infrastructure (HCI) cluster that provides VM hosting and storage for the lab. It uses native Harvester CRDs rather than Crossplane XRs.
+
+**Key Characteristics:**
+- No Crossplane abstractions - raw Harvester CRDs
+- Provisioned via Tinkerbell PXE boot on MS-02 nodes
+- Registered as a managed cluster in Argo CD
+- Hosts platform cluster VMs (CP-2, CP-3) and standalone VMs
+
+**File Structure:**
+
+```
+clusters/harvester/
+├── config/
+│   ├── networks/
+│   │   ├── mgmt.yaml                   # VLAN 10 - Management network
+│   │   ├── platform.yaml               # VLAN 30 - Platform cluster network
+│   │   ├── cluster.yaml                # VLAN 40 - Tenant cluster network
+│   │   └── storage.yaml                # VLAN 60 - Storage replication network
+│   │
+│   └── images/
+│       └── talos-1.9.yaml              # Talos OS VM image template
+│
+└── vms/
+    ├── platform/
+    │   ├── cp-2.yaml                   # Platform control plane node 2
+    │   └── cp-3.yaml                   # Platform control plane node 3
+    │
+    └── standalone/
+        └── .gitkeep                    # Future: windows-gaming.yaml, truenas.yaml
+```
+
+**Network Configuration:**
+
+| File | VLAN | Purpose | Subnet |
+|:-----|:----:|:--------|:-------|
+| `mgmt.yaml` | 10 | Management network | 10.10.10.0/24 |
+| `platform.yaml` | 30 | Platform cluster nodes | 10.10.30.0/24 |
+| `cluster.yaml` | 40 | Tenant cluster nodes | 10.10.40.0/24 |
+| `storage.yaml` | 60 | Ceph replication traffic | 10.10.60.0/24 |
+
+**VM Types:**
+
+- **platform/** - Platform cluster VMs created during bootstrap (before CAPI is available)
+- **standalone/** - Non-containerized workloads (gaming PCs, file servers, etc.)
+- Tenant cluster VMs are NOT here - they are managed by CAPI via TenantCluster XR
+
+### Tenant Clusters (`clusters/media/`, `clusters/dev/`, `clusters/prod/`)
+
+Tenant clusters are application workload clusters provisioned entirely via Crossplane and CAPI.
+
+**Key Characteristics:**
+- Provisioned via TenantCluster XR Claim
+- CAPI creates Harvester VMs automatically
+- Automatically registered with Argo CD (via XR composition)
+- Applications deployed via XR Claims
+
+**File Structure:**
+
+```
+clusters/<tenant>/
+├── cluster.yaml                        # TenantCluster XR
+│                                       # Specifies: node count, resources, networking
+│
+├── core.yaml                           # CoreServices XR
+│                                       # - Istio
+│                                       # - cert-manager
+│                                       # - external-dns
+│
+└── apps/
+    └── <app-name>/
+        └── <app-name>.yaml             # Application XR
+```
+
+**Example: Media Cluster**
+
+```
+clusters/media/
+├── cluster.yaml                        # TenantCluster XR: 3 nodes, 32GB RAM each
+├── core.yaml                           # CoreServices XR
+└── apps/
+    ├── plex/
+    │   └── plex.yaml                   # Application XR
+    ├── jellyfin/
+    │   └── jellyfin.yaml               # Application XR
+    └── arr-stack/
+        └── arr-stack.yaml              # Application XR (Sonarr, Radarr, etc.)
+```
+
+### Cluster Discovery and Routing
+
+Argo CD uses two ApplicationSets to manage clusters:
+
+1. **cluster-definitions** - Syncs `*.yaml` files (cluster/core/platform XRs) to platform cluster
+2. **cluster-apps** - Uses matrix generator to sync `apps/*` to respective clusters
+
+See [ADR-003: GitOps Structure](../09_design_decisions/ADR-003-gitops-structure.md) for details.
+
+---
+
+## packages/ - Crossplane Configuration Packages
+
+Crossplane Configuration Packages define the XRDs (Custom Resource Definitions) and Compositions that power the platform's declarative infrastructure.
+
+### Package Types
+
+| Package | OCI Image | Git Tag Pattern | Purpose |
+|:--------|:----------|:----------------|:--------|
+| `packages/infrastructure/` | `ghcr.io/gilmanlab/xrp-infrastructure` | `infrastructure/vX.Y.Z` | Infrastructure primitives (TenantCluster, Hardware, Workflow) |
+| `packages/platform/` | `ghcr.io/gilmanlab/xrp-platform` | `platform/vX.Y.Z` | Platform services (CoreServices, PlatformServices, Application, Database) |
+
+### Infrastructure Package
+
+**Path:** `packages/infrastructure/`
+
+Defines infrastructure-level abstractions for cluster and hardware provisioning.
+
+**Structure:**
+
+```
+packages/infrastructure/
+├── crossplane.yaml                     # Package metadata
+├── apis/
+│   ├── tenant-cluster/
+│   │   ├── definition.yaml             # TenantCluster XRD
+│   │   └── composition.yaml            # CAPI + Harvester composition
+│   │
+│   ├── hardware/
+│   │   ├── definition.yaml             # Hardware XRD (Tinkerbell)
+│   │   └── composition.yaml            # Tinkerbell Hardware CRD composition
+│   │
+│   └── workflow/
+│       ├── definition.yaml             # Workflow XRD (Tinkerbell)
+│       └── composition.yaml            # Tinkerbell Workflow CRD composition
+│
+└── functions/
+    └── ...                             # Crossplane composition functions
+```
+
+**XRDs Defined:**
+
+- **TenantCluster** - Provisions a complete Kubernetes cluster via CAPI on Harvester
+- **Hardware** - Registers bare-metal hardware with Tinkerbell for PXE provisioning
+- **Workflow** - Defines Tinkerbell workflows for OS installation (Talos, Harvester)
+
+### Platform Package
+
+**Path:** `packages/platform/`
+
+Defines platform-level abstractions for Kubernetes workloads and services.
+
+**Structure:**
+
+```
+packages/platform/
+├── crossplane.yaml                     # Package metadata
+├── apis/
+│   ├── core-services/
+│   │   ├── definition.yaml             # CoreServices XRD
+│   │   └── composition.yaml            # Base cluster services
+│   │
+│   ├── platform-services/
+│   │   ├── definition.yaml             # PlatformServices XRD
+│   │   └── composition.yaml            # Shared platform services
+│   │
+│   ├── application/
+│   │   ├── definition.yaml             # Application XRD
+│   │   └── composition.yaml            # Standardized app deployment
+│   │
+│   └── database/
+│       ├── definition.yaml             # Database XRD
+│       └── composition.yaml            # CloudNativePG composition
+│
+└── functions/
+    └── ...                             # Crossplane composition functions
+```
+
+**XRDs Defined:**
+
+- **CoreServices** - Base cluster services (Crossplane, CAPI, cert-manager, Istio, etc.)
+- **PlatformServices** - Shared services (Zitadel, OpenBAO, VSO)
+- **Application** - Standardized application deployment (Helm + Istio ingress)
+- **Database** - PostgreSQL database provisioning (CloudNativePG)
+
+### Build and Release Process
+
+Crossplane packages are built and published automatically by GitHub Actions:
+
+1. Developer tags commit: `git tag infrastructure/v1.2.3`
+2. GitHub Action `.github/workflows/crossplane-build.yml` triggers
+3. Package is built using `crossplane xpkg build`
+4. OCI artifact is pushed to `ghcr.io/gilmanlab/xrp-infrastructure:v1.2.3`
+5. Argo CD can reference the new version in package installations
+
+**Workflow Files:**
+
+- `.github/workflows/crossplane-build.yml` - Builds and publishes packages on git tag push
+
+---
+
+## infrastructure/ - Pre-Kubernetes Configuration
+
+The `infrastructure/` directory contains configuration for systems that exist outside or before Kubernetes. This is NOT managed by Argo CD.
+
+### Structure
+
+```
+infrastructure/
+├── network/
+│   └── vyos/                           # VyOS router configuration
+│       ├── configs/
+│       │   └── gateway.conf            # VyOS declarative config
+│       └── ansible/
+│           ├── playbooks/
+│           │   └── deploy.yml          # Ansible playbook for VyOS deployment
+│           └── inventory/
+│               └── hosts.yml           # VyOS host inventory
+│
+├── compute/
+│   └── talos/                          # Talos configuration for platform cluster
+│       ├── talconfig.yaml              # talhelper configuration file
+│       ├── talsecret.sops.yaml         # SOPS-encrypted secrets
+│       ├── clusterconfig/              # Generated machine configs (gitignored)
+│       │   └── .gitkeep
+│       └── patches/                    # Machine config patches
+│           ├── common.yaml             # Applied to all nodes
+│           ├── controlplane.yaml       # Applied to control plane nodes
+│           └── worker.yaml             # Applied to worker nodes
+│
+└── provisioning/
+    └── tinkerbell/                     # Tinkerbell workflow templates
+        └── templates/
+            ├── harvester-install.yaml  # Harvester OS installation workflow
+            └── talos-install.yaml      # Talos OS installation workflow
+```
+
+### Network (`infrastructure/network/vyos/`)
+
+VyOS provides the lab's core networking: routing, firewall, DHCP, and VPN.
+
+**Bootstrap Image (Packer):**
+- VyOS is provisioned via Tinkerbell during genesis bootstrap
+- Packer builds a raw disk image with the initial configuration baked in
+- Image includes: VLANs, DHCP relay, BGP peering config, and firewall rules
+- Built once during initial bootstrap; stored on NAS for Tinkerbell to serve
+- Future configuration changes use the Ansible CI/CD pipeline (not Packer rebuild)
+
+**Packer Build (`infrastructure/network/vyos/packer/`):**
+- `vyos.pkr.hcl` - Packer template defining image build
+- `variables.pkr.hcl` - Variables (VyOS version, output format, etc.)
+- `http/preseed.cfg` - VyOS preseed for automated installation
+- `scripts/provision.sh` - Applies initial config from `configs/gateway.conf`
+
+**Ongoing Management:**
+- Configuration stored as declarative VyOS config file
+- Deployed via Ansible playbook
+- GitHub Action validates config on PR
+- GitHub Action deploys config on merge to main
+
+**Workflow Files:**
+- `.github/workflows/vyos-validate.yml` - Validates VyOS config on PR
+- `.github/workflows/vyos-deploy.yml` - Deploys VyOS config on merge
+
+**VLANs Managed:**
+
+| VLAN | Purpose | Subnet | Services |
+|:-----|:--------|:-------|:---------|
+| 10 | Management | 10.10.10.0/24 | SSH, IPMI, iDRAC |
+| 20 | Services | 10.10.20.0/24 | NAS, DNS, DHCP |
+| 30 | Platform | 10.10.30.0/24 | Platform cluster nodes |
+| 40 | Cluster | 10.10.40.0/24 | Tenant cluster nodes |
+| 60 | Storage | 10.10.60.0/24 | Ceph replication |
+
+### Compute (`infrastructure/compute/talos/`)
+
+Talos Linux configuration for the platform cluster, managed by talhelper.
+
+**talhelper Workflow:**
+
+1. Edit `talconfig.yaml` to define cluster nodes
+2. Run `talhelper genconfig` to generate machine configs
+3. Configs are encrypted with SOPS and served via NGINX during PXE boot
+4. Nodes fetch their configs and join the cluster
+
+**Files:**
+
+- `talconfig.yaml` - Declarative cluster definition (nodes, endpoints, patches)
+- `talsecret.sops.yaml` - SOPS-encrypted secrets (CA certs, tokens, etc.)
+- `clusterconfig/` - Generated machine configs (gitignored, regenerated each bootstrap)
+- `patches/` - Reusable machine config patches
+
+**Why Not in clusters/platform/?**
+
+Platform cluster configuration must exist BEFORE Kubernetes is running. It cannot be managed by Argo CD because Argo CD doesn't exist yet during bootstrap.
+
+**Tenant Cluster Talos Configs:**
+
+Tenant clusters use CAPI with the Talos provider, which generates machine configs automatically. Patches for tenant clusters are embedded in the TenantCluster XRD composition in `packages/infrastructure/`.
+
+### Provisioning (`infrastructure/provisioning/tinkerbell/`)
+
+Tinkerbell workflow templates for bare-metal OS installation.
+
+**Templates:**
+
+- `harvester-install.yaml` - Installs Harvester OS on MS-02 nodes
+- `talos-install.yaml` - Installs Talos Linux on bare-metal nodes
+
+**Template vs Instance:**
+
+- **Templates** live in `infrastructure/provisioning/tinkerbell/templates/` (not cluster-specific)
+- **Instances** are created via Workflow XR Claims in `clusters/platform/apps/tinkerbell/workflows/`
+
+---
+
+## bootstrap/ - Bootstrap and Recovery
+
+The `bootstrap/` directory contains one-time bootstrap procedures and disaster recovery runbooks.
+
+### Structure
+
+```
+bootstrap/
+├── seed/                               # Seed phase bootstrap manifests
+│   ├── tinkerbell/                     # Raw Tinkerbell deployment
+│   ├── hardware/                       # UM760 hardware definition
+│   ├── workflows/                      # UM760 provisioning workflow
+│   └── config-server/                  # NGINX for Talos configs
+│
+├── genesis/                            # Bootstrap runbooks and scripts
+│   ├── README.md                       # Overview and prerequisites
+│   ├── 01-seed-cluster.md
+│   ├── 02-deploy-argocd.md
+│   ├── 03-apply-bootstrap.md
+│   ├── 04-um760-provisioning.md
+│   ├── 05-migrate-to-um760.md
+│   ├── 06-deploy-platform.md
+│   ├── 07-provision-harvester.md
+│   ├── 08-expand-platform.md
+│   └── scripts/
+│       ├── generate-talos-config.sh
+│       ├── create-seed-vm.sh
+│       └── install-argocd.sh
+│
+└── recovery/
+    ├── etcd-restore.md
+    ├── platform-rebuild.md
+    └── scripts/
+        └── restore-etcd.sh
+```
+
+### Seed (`bootstrap/seed/`)
+
+Raw Kubernetes manifests for the minimal seed cluster that runs on the NAS.
+
+**Purpose:**
+- Deploy Tinkerbell on resource-constrained NAS (32GB RAM)
+- Provision VyOS router via PXE (establishes lab networking)
+- Provision UM760 via PXE (first platform cluster node)
+- Migrate to UM760 and delete seed manifests
+- Replace with full platform deployment (XR-based)
+
+**Bootstrap Targets:**
+
+| Hardware | Workflow | Result |
+|:---------|:---------|:-------|
+| VP6630 | `vp6630-vyos.yaml` | VyOS router with lab networking config |
+| UM760 | `um760-talos.yaml` | First platform cluster control plane node |
+
+**Why Raw Manifests?**
+
+The seed cluster faces a chicken-and-egg problem: Crossplane is needed to process XRs, but Crossplane is deployed via XRs. Solution: bootstrap with raw manifests, then delete and redeploy via XRs.
+
+See [Appendix B: Bootstrap Procedure](B_bootstrap_procedure.md) for details.
+
+### Genesis (`bootstrap/genesis/`)
+
+Step-by-step runbooks and scripts for bootstrapping the lab from scratch.
+
+**Runbooks (in order):**
+
+1. `01-build-vyos-image.md` - Build VyOS image with Packer (bakes in initial config)
+2. `02-seed-cluster.md` - Create Talos VM on NAS
+3. `03-deploy-argocd.md` - Install Argo CD manually via Helm
+4. `04-apply-bootstrap.md` - Apply bootstrap Application pointing to `bootstrap/seed/`
+5. `05-vyos-provisioning.md` - Wait for VyOS to PXE boot (establishes lab networking)
+6. `06-um760-provisioning.md` - Wait for UM760 to PXE boot and join cluster
+7. `07-migrate-to-um760.md` - Drain NAS, migrate workloads to UM760
+8. `08-deploy-platform.md` - Delete bootstrap App, deploy full platform via XRs
+9. `09-provision-harvester.md` - Use Tinkerbell to provision MS-02 nodes with Harvester
+10. `10-expand-platform.md` - Create CP-2/CP-3 VMs on Harvester, expand platform to 3 nodes
+
+**Scripts:**
+
+- `build-vyos-image.sh` - Runs Packer to build VyOS raw disk image
+- `generate-talos-config.sh` - Runs talhelper to generate machine configs
+- `create-seed-vm.sh` - Creates Talos VM on NAS
+- `install-argocd.sh` - Installs Argo CD via Helm
+
+### Recovery (`bootstrap/recovery/`)
+
+Disaster recovery procedures for catastrophic failures.
+
+**Scenarios:**
+
+- `etcd-restore.md` - Restore platform cluster from etcd backup
+- `platform-rebuild.md` - Rebuild platform cluster from scratch
+
+---
+
+## Management Summary
+
+### What is Argo CD Managed?
+
+| Directory | Argo CD Managed | Mechanism |
+|:----------|:---------------:|:----------|
+| `clusters/platform/` | Yes | ApplicationSet `cluster-definitions` + `cluster-apps` |
+| `clusters/harvester/` | Yes | ApplicationSet `cluster-apps` (after manual registration) |
+| `clusters/media/` | Yes | ApplicationSet `cluster-definitions` + `cluster-apps` |
+| `clusters/dev/` | Yes | ApplicationSet `cluster-definitions` + `cluster-apps` |
+| `clusters/prod/` | Yes | ApplicationSet `cluster-definitions` + `cluster-apps` |
+| `bootstrap/seed/` | One-time | Manual Application (deleted after migration) |
+| `infrastructure/` | No | Manual, Ansible, talhelper |
+| `packages/` | No | Built by CI/CD, consumed by Crossplane |
+
+### What is NOT Argo CD Managed?
+
+| Directory | Management Method | Reason |
+|:----------|:------------------|:-------|
+| `infrastructure/network/vyos/` | Ansible (GitHub Actions) | Pre-Kubernetes networking |
+| `infrastructure/compute/talos/` | talhelper (manual) | Platform cluster bootstrap config |
+| `infrastructure/provisioning/tinkerbell/` | Reference templates | Not cluster-specific |
+| `packages/` | GitHub Actions (OCI build) | Source code for XRDs |
+| `bootstrap/genesis/` | Manual execution | One-time bootstrap runbooks |
+| `bootstrap/recovery/` | Manual execution | Disaster recovery procedures |
+
+---
+
+## Naming Conventions
+
+### Directories
+
+- **Lowercase with hyphens:** `tenant-cluster`, `core-services`, `platform-services`
+- **Plural for collections:** `clusters/`, `packages/`, `workflows/`, `networks/`
+- **Singular for instances:** `infrastructure/`, `bootstrap/`
+
+### Files
+
+- **Lowercase with hyphens:** `cluster.yaml`, `core-services.yaml`, `talos-install.yaml`
+- **Descriptive names:** `ms02-node1.yaml`, `harvester.yaml`, `prometheus.yaml`
+- **XR Claims:** Named after the resource: `plex.yaml`, `jellyfin.yaml`, `media.yaml`
+
+### Git Tags
+
+- **Crossplane packages:** `<package-name>/vX.Y.Z`
+  - Example: `infrastructure/v1.2.3`, `platform/v2.0.1`
+- **Semantic versioning:** MAJOR.MINOR.PATCH
+  - MAJOR: Breaking changes to XRD API
+  - MINOR: New features, backwards compatible
+  - PATCH: Bug fixes
+
+### Cluster Names
+
+- **Platform cluster:** `platform`
+- **Harvester cluster:** `harvester`
+- **Tenant clusters:** Descriptive names based on purpose
+  - Examples: `media`, `dev`, `prod`, `staging`
+
+### XRD API Groups
+
+- **Infrastructure:** `infrastructure.lab.gilman.io`
+- **Platform:** `platform.lab.gilman.io`
+
+### OCI Image Names
+
+- **Pattern:** `ghcr.io/gilmanlab/xrp-<package-name>:<version>`
+- **Examples:**
+  - `ghcr.io/gilmanlab/xrp-infrastructure:v1.2.3`
+  - `ghcr.io/gilmanlab/xrp-platform:v2.0.1`
+
+---
+
+## Cross-References
+
+- [Appendix B: Bootstrap Procedure](B_bootstrap_procedure.md) - Detailed bootstrap process
+- [ADR-003: GitOps Structure](../09_design_decisions/ADR-003-gitops-structure.md) - Argo CD ApplicationSet patterns
+- [Concept: Crossplane Abstractions](../08_concepts/crossplane-abstractions.md) - XRD design philosophy
+- [Deployment View](../07_deployment_view.md) - Physical and logical deployment architecture

--- a/docs/architecture/appendices/B_bootstrap_procedure.md
+++ b/docs/architecture/appendices/B_bootstrap_procedure.md
@@ -1,0 +1,1060 @@
+# Appendix B: Bootstrap Procedure Reference
+
+> **Status**: Authoritative Reference
+> **Date**: 2025-12-19
+
+This document defines the architectural design of the lab bootstrap process. It describes WHAT happens at each phase and WHY, not HOW to execute commands (see `bootstrap/genesis/` runbooks for step-by-step instructions).
+
+---
+
+## Table of Contents
+
+1. [Overview](#overview)
+2. [Design Principles](#design-principles)
+3. [Bootstrap Phases](#bootstrap-phases)
+4. [Phase 1: Seed (NAS)](#phase-1-seed-nas)
+5. [Phase 2: Single-Node Platform (UM760)](#phase-2-single-node-platform-um760)
+6. [Phase 3: Harvester Online](#phase-3-harvester-online)
+7. [Phase 4: Full Platform (3-Node HA)](#phase-4-full-platform-3-node-ha)
+8. [Bootstrap Progression Diagram](#bootstrap-progression-diagram)
+9. [Complete Step Reference](#complete-step-reference)
+10. [Prerequisites](#prerequisites)
+11. [Post-Bootstrap State](#post-bootstrap-state)
+
+---
+
+## Overview
+
+The lab infrastructure bootstrap is a carefully orchestrated 4-phase process that progressively builds the platform from a minimal seed cluster to a fully operational, highly available control plane.
+
+### The Chicken-and-Egg Problem
+
+The platform cluster hosts the very tools needed to provision infrastructure:
+- **Crossplane** processes XR Claims to provision resources
+- **CAPI** provisions tenant Kubernetes clusters
+- **Tinkerbell** provisions bare-metal hardware via PXE
+
+This creates a dependency loop: we cannot use these tools to bootstrap the platform that hosts them.
+
+### The Solution: Progressive Bootstrap
+
+1. **Start minimal** - Seed cluster on NAS with only Tinkerbell (no Crossplane)
+2. **Provision foundation** - Use Tinkerbell to PXE boot UM760 (first platform node)
+3. **Migrate and upgrade** - Move to UM760, deploy full platform with Crossplane/CAPI
+4. **Scale out** - Use Tinkerbell to provision Harvester, then expand platform to 3 nodes
+
+By the end, the platform is self-managing via Crossplane XRs.
+
+---
+
+## Design Principles
+
+| Principle | Rationale |
+|:----------|:----------|
+| **Resource efficiency** | Seed cluster uses minimal RAM (NAS has only 32GB shared with Synology) |
+| **Progressive complexity** | Each phase adds capability only when needed |
+| **GitOps from the start** | Even seed cluster uses Argo CD (though with raw manifests) |
+| **Reproducibility** | Entire process documented and scriptable |
+| **Self-healing target** | Final state is fully declarative and self-managing |
+
+---
+
+## Bootstrap Phases
+
+The bootstrap is divided into 4 phases, spanning 20 discrete steps.
+
+```
+Phase 1: Seed (NAS)
+  Steps 1-8: Build images, minimal cluster with Tinkerbell, provision VyOS and UM760
+  Duration: ~45 minutes
+  Result: VyOS router online, UM760 joins cluster via PXE
+
+Phase 2: Single-Node Platform (UM760)
+  Steps 9-13: Migrate to UM760, deploy full platform
+  Duration: ~1 hour
+  Result: Platform cluster with Crossplane, CAPI, Harvester provisioned
+
+Phase 3: Harvester Online
+  Steps 14-17: Register Harvester, create platform VMs
+  Duration: ~2 hours (Harvester install is slow)
+  Result: CP-2 and CP-3 join platform cluster
+
+Phase 4: Full Platform (3-Node HA)
+  Steps 18-20: Deploy remaining services, steady state
+  Duration: ~30 minutes
+  Result: Full platform operational, ready for tenant clusters
+```
+
+**Total Duration:** ~4.5 hours (mostly waiting for Harvester installation)
+
+---
+
+## Phase 1: Seed (NAS)
+
+**Goal:** Create a minimal Kubernetes cluster on the NAS that can provision VyOS (lab networking) and UM760 (first platform node) via PXE.
+
+**Resource Constraints:**
+- NAS has 32GB RAM shared with Synology DSM
+- Talos VM allocated: 4 vCPU, 8GB RAM, 40GB disk
+- Single-node cluster (no HA required for temporary seed)
+
+**What Runs on the Seed:**
+- Argo CD (GitOps controller)
+- Tinkerbell (PXE/DHCP/TFTP services)
+- NGINX (serves Talos machine configs and VyOS image)
+
+**What Does NOT Run on the Seed:**
+- Crossplane (too heavyweight, not needed yet)
+- CAPI (requires Crossplane)
+- CoreServices (Istio, cert-manager, etc.)
+- PlatformServices (Zitadel, OpenBAO, etc.)
+
+### Step 1: Build VyOS Image
+
+**Purpose:** Create a bootable VyOS disk image with the initial lab configuration baked in.
+
+**Mechanism:**
+- Run Packer against `infrastructure/network/vyos/packer/vyos.pkr.hcl`
+- Packer downloads VyOS ISO, installs to virtual disk, applies initial config
+- Configuration sourced from `infrastructure/network/vyos/configs/gateway.conf`
+- Output: Raw disk image stored on NAS for Tinkerbell to serve
+
+**Why Now:**
+- VyOS image must exist before Tinkerbell can serve it
+- Baking config into image avoids manual configuration during bootstrap
+- Packer runs on admin workstation (not in cluster)
+
+**Image Contents:**
+- VyOS LTS release
+- Pre-configured VLANs (10, 20, 30, 40, 50, 60)
+- DHCP relay for VLANs 30 and 40 (points to Tinkerbell)
+- BGP peering configuration for service VIPs
+- Firewall rules for lab isolation
+- SSH keys for initial access
+
+**Output:**
+```
+infrastructure/network/vyos/packer/output/
+└── vyos-lab.raw              # Raw disk image (~2GB)
+```
+
+### Step 2: Generate Talos Configs
+
+**Purpose:** Create encrypted machine configurations for all platform cluster nodes.
+
+**Mechanism:**
+- Run talhelper against `infrastructure/compute/talos/talconfig.yaml`
+- Generates configs for: CP-1 (UM760), CP-2 (Harvester VM), CP-3 (Harvester VM)
+- Encrypts secrets with SOPS
+- Output: `infrastructure/compute/talos/clusterconfig/` (gitignored)
+
+**Why Now:**
+- Configs must exist before nodes can boot
+- talhelper runs on admin workstation (not in cluster)
+
+**Files Generated:**
+```
+infrastructure/compute/talos/clusterconfig/
+├── platform-cp-1.yaml          # UM760 (MAC: xx:xx:xx:xx:xx:01)
+├── platform-cp-2.yaml          # Harvester VM (created in Phase 3)
+├── platform-cp-3.yaml          # Harvester VM (created in Phase 3)
+└── talosconfig                 # Admin kubeconfig for talosctl
+```
+
+### Step 3: Create Seed Talos VM
+
+**Purpose:** Create the initial Kubernetes node on the NAS.
+
+**Mechanism:**
+- Use Synology Virtual Machine Manager
+- Allocate resources: 4 vCPU, 8GB RAM, 40GB disk
+- Attach Talos ISO
+- Boot and apply minimal Talos config (single-node cluster)
+
+**Why Manual:**
+- Cannot PXE boot on NAS (no Tinkerbell yet)
+- One-time operation, not worth automating
+
+**Result:**
+- Single-node Talos cluster running on NAS
+- No workloads yet (just Kubernetes API)
+
+### Step 4: Deploy Argo CD
+
+**Purpose:** Establish GitOps controller to manage all subsequent deployments.
+
+**Mechanism:**
+- Install Argo CD via Helm CLI (manual)
+- Use `bootstrap/genesis/scripts/install-argocd.sh`
+- Register platform cluster with itself (in-cluster registration)
+
+**Why Argo CD First:**
+- All subsequent components deployed via GitOps
+- Enables declarative, version-controlled infrastructure
+- Argo CD is lightweight enough for seed cluster
+
+**Configuration:**
+```yaml
+# Created by install-argocd.sh
+apiVersion: v1
+kind: Secret
+metadata:
+  name: platform
+  namespace: argocd
+  labels:
+    argocd.argoproj.io/secret-type: cluster
+    lab.gilman.io/cluster-name: platform
+stringData:
+  name: platform
+  server: https://kubernetes.default.svc  # In-cluster
+```
+
+### Step 5: Apply Bootstrap Application
+
+**Purpose:** Deploy Tinkerbell and provisioning configurations for VyOS and UM760.
+
+**Mechanism:**
+- Create Argo CD Application pointing to `bootstrap/seed/`
+- Argo CD syncs raw Kubernetes manifests (NOT XRs)
+- Deployed: Tinkerbell stack, Hardware CRDs (VP6630, UM760), Workflow CRDs (VyOS, Talos), NGINX config server
+
+**Why Raw Manifests:**
+- Crossplane is not running yet (cannot process XRs)
+- Temporary deployment (will be deleted and redeployed as XRs in Phase 2)
+
+**Application Definition:**
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: bootstrap
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/gilmanlab/lab.git
+    targetRevision: HEAD
+    path: bootstrap/seed
+    directory:
+      recurse: true
+  destination:
+    server: https://kubernetes.default.svc
+  syncPolicy:
+    automated:
+      selfHeal: true
+      prune: false  # Manual cleanup after migration
+```
+
+**What Gets Deployed:**
+
+| Component | Purpose |
+|:----------|:--------|
+| Tinkerbell namespace | Isolation for Tinkerbell services |
+| Tinkerbell Helm release | Boots, Hegel, Rufio, Tink server, Tink worker |
+| Hardware CRD (VP6630) | Registers VyOS router MAC address, BMC, network config |
+| Hardware CRD (UM760) | Registers UM760 MAC address, BMC, network config |
+| Workflow CRD (VyOS) | Defines VyOS installation workflow for VP6630 |
+| Workflow CRD (Talos) | Defines Talos installation workflow for UM760 |
+| NGINX deployment | Serves VyOS image and talhelper-generated Talos configs over HTTP |
+
+### Step 6: Tinkerbell Deploys
+
+**Purpose:** Tinkerbell services come online and begin listening for PXE requests.
+
+**Mechanism:**
+- Boots (DHCP server) starts serving VLAN 30 (platform network)
+- Hegel (metadata server) provides hardware-specific config
+- Tink server stores workflows and hardware definitions
+- Tink worker polls for workflow executions
+
+**Services Exposed:**
+
+| Service | Protocol | Port | Purpose |
+|:--------|:---------|:-----|:--------|
+| Boots | DHCP | 67 | PXE boot DHCP |
+| Boots | TFTP | 69 | Kernel/initrd transfer |
+| Boots | HTTP | 8080 | iPXE scripts, OS images |
+| Hegel | HTTP | 50061 | Metadata API |
+| NGINX | HTTP | 8081 | VyOS image and Talos machine configs |
+
+**Result:**
+- Tinkerbell ready to provision VyOS and UM760
+- Network boot infrastructure operational
+
+### Step 7: VyOS Boots via PXE
+
+**Purpose:** Provision the VyOS router to establish lab networking infrastructure.
+
+**Mechanism:**
+1. Power on VP6630 with PXE boot enabled
+2. VP6630 sends DHCP request (bootstrap network)
+3. Boots responds with PXE boot parameters
+4. VP6630 downloads iPXE script, kernel, initrd
+5. Tinkerbell Workflow executes:
+   - Downloads VyOS raw image from NGINX
+   - Writes VyOS image to disk
+   - Reboots into VyOS
+6. VyOS boots with pre-configured lab networking
+
+**Why VyOS First:**
+- Lab VLANs must exist before UM760 can PXE boot on VLAN 30
+- DHCP relay configuration routes PXE requests to Tinkerbell
+- Without VyOS, UM760 cannot reach Tinkerbell on the provisioning network
+
+**What Gets Configured:**
+- VLANs 10, 20, 30, 40, 50, 60 on trunk interfaces
+- DHCP relay for VLANs 30 and 40 (points to Tinkerbell IP)
+- Inter-VLAN routing enabled
+- BGP peering configuration (inactive until Cilium peers)
+- Firewall rules for lab isolation from home network
+
+**Timeline:**
+- PXE boot: ~2 minutes
+- VyOS install: ~3 minutes
+- VyOS boot with config: ~1 minute
+- **Total: ~6 minutes**
+
+**Result:**
+- Lab networking operational
+- VLANs available for subsequent provisioning
+- DHCP relay active for platform and cluster networks
+
+### Step 8: UM760 Boots via PXE
+
+**Purpose:** Provision the UM760 as the first production platform node.
+
+**Mechanism:**
+1. Power on UM760 with PXE boot enabled
+2. UM760 sends DHCP request (VLAN 30 via VyOS DHCP relay)
+3. Boots responds with PXE boot parameters
+4. UM760 downloads iPXE script, kernel, initrd
+5. Tinkerbell Workflow executes:
+   - Downloads Talos image
+   - Fetches machine config from NGINX (cp-1.yaml)
+   - Writes Talos to disk
+   - Reboots into Talos
+6. Talos bootstraps and joins cluster as CP-1
+
+**What Makes UM760 Special:**
+- MAC address matches Hardware CRD: `00:68:eb:xx:xx:01`
+- Workflow triggered automatically when UM760 PXE boots
+- Talos config URL served via Hegel metadata
+
+**Timeline:**
+- PXE boot: ~2 minutes
+- Talos install: ~5 minutes
+- Cluster join: ~2 minutes
+- **Total: ~10 minutes**
+
+**Result:**
+- Platform cluster now has 2 nodes: NAS VM + UM760
+- UM760 is control plane + worker (hybrid)
+
+---
+
+## Phase 2: Single-Node Platform (UM760)
+
+**Goal:** Migrate workloads from NAS to UM760, delete temporary seed manifests, and deploy full platform with Crossplane/CAPI.
+
+**Why Migrate:**
+- UM760 has more resources (64GB RAM vs 8GB)
+- NAS can be shut down (reclaim 8GB RAM for DSM)
+- UM760 is production hardware (UM760 is permanent, NAS was temporary)
+
+### Step 9: Migrate Workloads to UM760
+
+**Purpose:** Move all running pods from NAS to UM760.
+
+**Mechanism:**
+- Cordon NAS node: `kubectl cordon platform-cp-0`
+- Drain NAS node: `kubectl drain platform-cp-0 --ignore-daemonsets --delete-emptydir-data`
+- Wait for pods to reschedule on UM760
+- Power off NAS VM (optional, or keep as backup)
+
+**Workloads Migrated:**
+- Argo CD (controller, server, repo-server)
+- Tinkerbell stack (Boots, Hegel, Rufio, Tink)
+- NGINX config server
+
+**Result:**
+- All workloads running on UM760
+- NAS node idle (can be removed from cluster or powered off)
+
+### Step 10: Delete Bootstrap Application
+
+**Purpose:** Remove temporary seed manifests to make room for XR-based deployment.
+
+**Mechanism:**
+- Delete Argo CD Application: `kubectl delete application bootstrap -n argocd`
+- Manually delete any remaining resources (if not pruned)
+- Tinkerbell namespace and resources removed
+
+**Why Delete:**
+- Seed used raw manifests; production uses XRs
+- Cannot have both raw Tinkerbell and XR-based Tinkerbell simultaneously
+- Clean slate for proper deployment
+
+**Result:**
+- No Tinkerbell running (temporarily)
+- Argo CD still running
+- UM760 still in cluster (Talos is persistent)
+
+### Step 11: Apply Platform Configuration
+
+**Purpose:** Deploy full platform cluster configuration via Crossplane XRs.
+
+**Mechanism:**
+- Create ApplicationSet: `kubectl apply -f argocd/applicationsets/cluster-definitions.yaml`
+- Argo CD discovers `clusters/platform/` directory
+- Syncs `core.yaml` and `platform.yaml` to platform cluster
+
+**What Gets Deployed:**
+
+| File | XR Type | What It Provisions |
+|:-----|:--------|:-------------------|
+| `clusters/platform/core.yaml` | CoreServices | Crossplane, CAPI, cert-manager, external-dns, Istio |
+| `clusters/platform/platform.yaml` | PlatformServices | Zitadel, OpenBAO, Vault Secrets Operator |
+
+**Sync Waves:**
+- Wave 0: `core.yaml` (Crossplane must be running first)
+- Wave 1: `platform.yaml` (depends on Crossplane)
+- Wave 2: `apps/*` (depends on CoreServices)
+
+**Result:**
+- Crossplane is running
+- CAPI is installed (but no clusters yet)
+- cert-manager, external-dns, Istio deployed
+- Zitadel and OpenBAO deployed
+
+### Step 12: Crossplane + Tinkerbell (XRD)
+
+**Purpose:** Redeploy Tinkerbell via proper Crossplane abstraction.
+
+**Mechanism:**
+- ApplicationSet discovers `clusters/platform/apps/tinkerbell/`
+- Argo CD syncs Hardware XRs and Workflow XRs
+- Crossplane processes XRs and creates Tinkerbell Hardware/Workflow CRDs
+
+**Files Synced:**
+```
+clusters/platform/apps/tinkerbell/
+├── hardware/
+│   ├── ms02-node1.yaml         # Hardware XR for Harvester node 1
+│   ├── ms02-node2.yaml         # Hardware XR for Harvester node 2
+│   ├── ms02-node3.yaml         # Hardware XR for Harvester node 3
+│   └── um760.yaml              # Hardware XR for UM760 (already provisioned)
+└── workflows/
+    ├── harvester.yaml          # Workflow XR for Harvester installation
+    └── talos.yaml              # Workflow XR for Talos installation
+```
+
+**Result:**
+- Tinkerbell redeployed via XRs (now permanent)
+- Hardware definitions registered for MS-02 nodes (Harvester cluster)
+- Workflows ready to provision Harvester
+
+### Step 13: Provision Harvester
+
+**Purpose:** Install Harvester OS on MS-02 nodes to create HCI cluster.
+
+**Mechanism:**
+1. Power on MS-02 nodes with PXE boot enabled
+2. Tinkerbell detects hardware (MAC addresses match Hardware XRs)
+3. Executes Harvester installation workflow:
+   - Downloads Harvester ISO
+   - Writes Harvester to disk
+   - Applies Harvester config (cluster token, network config)
+   - Reboots into Harvester
+4. Harvester cluster self-forms (3-node)
+
+**Harvester Installation:**
+- **Duration:** ~1.5 hours (Harvester install is slow)
+- **Result:** 3-node Harvester cluster running on MS-02 hardware
+- **Services:** Longhorn (storage), Harvester VMs, Harvester networking
+
+**Harvester Cluster Details:**
+
+| Node | Hardware | Role | IP (VLAN 10 - Mgmt) |
+|:-----|:---------|:-----|:--------------------|
+| ms02-node1 | MS-02 | Control Plane + Compute | 10.10.10.11 |
+| ms02-node2 | MS-02 | Control Plane + Compute | 10.10.10.12 |
+| ms02-node3 | MS-02 | Control Plane + Compute | 10.10.10.13 |
+
+**Result:**
+- Harvester cluster operational
+- Ready to host VMs
+- Platform cluster still single-node (UM760)
+
+---
+
+## Phase 3: Harvester Online
+
+**Goal:** Register Harvester with Argo CD, deploy VM configurations, and create CP-2/CP-3 VMs to expand platform cluster.
+
+**Why This Phase:**
+- Platform cluster is still single-node (no HA)
+- Need VMs on Harvester to add CP-2 and CP-3
+- Harvester must be registered with Argo CD before it can be managed
+
+### Step 14: Register Harvester with Argo CD
+
+**Purpose:** Allow Argo CD to deploy resources to Harvester cluster.
+
+**Mechanism:**
+- Extract Harvester kubeconfig (from Harvester UI or API)
+- Create Argo CD cluster Secret with Harvester endpoint and credentials
+- Label Secret with `lab.gilman.io/cluster-name: harvester`
+
+**Cluster Secret:**
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: harvester
+  namespace: argocd
+  labels:
+    argocd.argoproj.io/secret-type: cluster
+    lab.gilman.io/cluster-name: harvester
+type: Opaque
+stringData:
+  name: harvester
+  server: https://10.10.10.11:6443  # Harvester API endpoint
+  config: |
+    {
+      "tlsClientConfig": {
+        "caData": "...",
+        "certData": "...",
+        "keyData": "..."
+      }
+    }
+```
+
+**Result:**
+- Harvester appears in Argo CD cluster list
+- ApplicationSet can now route apps to Harvester
+
+### Step 15: Argo CD Syncs `clusters/harvester/`
+
+**Purpose:** Deploy Harvester network configuration, VM images, and VM definitions.
+
+**Mechanism:**
+- ApplicationSet matrix generator discovers Harvester cluster + `clusters/harvester/` directory
+- Argo CD syncs to Harvester cluster (not platform)
+- Deploys raw Harvester CRDs (ClusterNetwork, VlanConfig, VirtualMachineImage, VirtualMachine)
+
+**What Gets Deployed:**
+
+**Networks (clusters/harvester/config/networks/):**
+
+| File | VLAN | Purpose | Subnet |
+|:-----|:----:|:--------|:-------|
+| `mgmt.yaml` | 10 | Management network | 10.10.10.0/24 |
+| `platform.yaml` | 30 | Platform cluster network | 10.10.30.0/24 |
+| `cluster.yaml` | 40 | Tenant cluster network | 10.10.40.0/24 |
+| `storage.yaml` | 60 | Ceph replication network | 10.10.60.0/24 |
+
+**Images (clusters/harvester/config/images/):**
+
+| File | Image | Purpose |
+|:-----|:------|:--------|
+| `talos-1.9.yaml` | Talos 1.9 VM image | OS for platform cluster VMs |
+
+**VMs (clusters/harvester/vms/platform/):**
+
+| File | VM Name | vCPU | RAM | Disk | Network | MAC Address |
+|:-----|:--------|:-----|:----|:-----|:--------|:------------|
+| `cp-2.yaml` | platform-cp-2 | 8 | 16GB | 100GB | VLAN 30 | 52:54:00:xx:xx:02 |
+| `cp-3.yaml` | platform-cp-3 | 8 | 16GB | 100GB | VLAN 30 | 52:54:00:xx:xx:03 |
+
+**Result:**
+- Harvester networks configured
+- Talos VM image available
+- CP-2 and CP-3 VMs created (powered off initially)
+
+### Step 16: CP-2, CP-3 VMs Created
+
+**Purpose:** Create VirtualMachine resources on Harvester for platform cluster nodes.
+
+**Mechanism:**
+- Harvester processes VirtualMachine CRDs
+- Allocates resources from Longhorn storage
+- Attaches to VLAN 30 (platform network)
+- VMs created in powered-off state
+
+**VM Specifications:**
+
+| Parameter | CP-2 | CP-3 |
+|:----------|:-----|:-----|
+| CPU | 8 vCPU | 8 vCPU |
+| RAM | 16GB | 16GB |
+| Disk | 100GB (Longhorn) | 100GB (Longhorn) |
+| Network | VLAN 30 | VLAN 30 |
+| MAC | 52:54:00:xx:xx:02 | 52:54:00:xx:xx:03 |
+| Boot Order | Network (PXE) → Disk | Network (PXE) → Disk |
+
+**Result:**
+- VMs exist but not yet running
+- Ready for PXE boot
+
+### Step 17: CP-2, CP-3 PXE Boot
+
+**Purpose:** Provision CP-2 and CP-3 with Talos OS and join platform cluster.
+
+**Mechanism:**
+1. Power on CP-2 and CP-3 VMs
+2. VMs PXE boot (first boot device is network)
+3. Tinkerbell detects VMs (MAC addresses match Hardware XRs)
+4. Executes Talos installation workflow:
+   - Downloads Talos image
+   - Fetches machine config from NGINX (cp-2.yaml, cp-3.yaml)
+   - Writes Talos to disk
+   - Reboots into Talos
+5. Talos bootstraps and joins platform cluster as CP-2, CP-3
+
+**Timeline:**
+- PXE boot (per VM): ~2 minutes
+- Talos install (per VM): ~5 minutes
+- Cluster join (per VM): ~2 minutes
+- **Total: ~20 minutes** (VMs can boot in parallel)
+
+**Result:**
+- Platform cluster now has 3 control plane nodes: CP-1 (UM760), CP-2 (VM), CP-3 (VM)
+- High availability achieved (etcd quorum: 2/3)
+
+---
+
+## Phase 4: Full Platform (3-Node HA)
+
+**Goal:** Deploy remaining platform services and reach steady state.
+
+**Why This Phase:**
+- Platform cluster is now HA (3 control plane nodes)
+- Safe to deploy production workloads
+- Infrastructure complete, ready for tenant clusters
+
+### Step 18: Deploy Remaining Platform Services
+
+**Purpose:** Activate all platform capabilities (observability, policy, etc.).
+
+**Mechanism:**
+- ApplicationSet discovers `clusters/platform/apps/*`
+- Argo CD syncs Application XRs to platform cluster
+- Crossplane processes XRs and deploys Helm releases
+
+**Services Deployed:**
+
+**Observability (clusters/platform/apps/observability/):**
+
+| File | Application | Purpose |
+|:-----|:------------|:--------|
+| `prometheus.yaml` | Prometheus | Metrics collection and alerting |
+| `grafana.yaml` | Grafana | Metrics visualization |
+| `loki.yaml` | Loki | Log aggregation |
+
+**CAPI (clusters/platform/apps/capi/):**
+
+| File | Purpose |
+|:-----|:--------|
+| `providers.yaml` | Install CAPI providers (Harvester, Talos) |
+| `harvester-config.yaml` | Configure Harvester provider with credentials |
+
+**Result:**
+- Full observability stack operational
+- CAPI ready to provision tenant clusters
+- Platform services fully deployed
+
+### Step 19: Steady State
+
+**Purpose:** Validate that all platform components are healthy and operational.
+
+**Validation Checklist:**
+
+| Component | Check | Expected Result |
+|:----------|:------|:----------------|
+| Platform cluster | `kubectl get nodes` | 3 nodes (CP-1, CP-2, CP-3) all Ready |
+| Harvester cluster | `kubectl get nodes --kubeconfig harvester` | 3 nodes (ms02-1, ms02-2, ms02-3) all Ready |
+| Crossplane | `kubectl get xrd` | All XRDs Established |
+| CAPI | `kubectl get providers -A` | Harvester and Talos providers Installed |
+| Argo CD | UI / `argocd app list` | All apps Healthy, Synced |
+| Tinkerbell | `kubectl get hardware -n tinkerbell` | All hardware Ready |
+| Istio | `kubectl get pods -n istio-system` | All pods Running |
+| Zitadel | `curl https://auth.lab.local` | 200 OK |
+| OpenBAO | `curl https://vault.lab.local` | 200 OK |
+
+**Result:**
+- Platform cluster is fully operational
+- All services healthy
+- Ready for tenant clusters
+
+### Step 20: Tenant Clusters
+
+**Purpose:** Begin provisioning application workload clusters.
+
+**Mechanism:**
+1. Create TenantCluster XR in `clusters/media/cluster.yaml`
+2. Commit and push to Git
+3. Argo CD syncs XR to platform cluster
+4. Crossplane processes TenantCluster XR:
+   - Creates CAPI Cluster resource
+   - CAPI Harvester provider creates VMs on Harvester
+   - CAPI Talos provider generates machine configs
+   - VMs PXE boot, install Talos, join cluster
+   - CAPI generates kubeconfig
+   - Crossplane creates Argo CD cluster Secret
+5. Argo CD discovers new cluster
+6. ApplicationSet syncs `clusters/media/apps/*` to media cluster
+
+**Example TenantCluster XR:**
+```yaml
+apiVersion: infrastructure.lab.gilman.io/v1alpha1
+kind: TenantCluster
+metadata:
+  name: media
+  namespace: default
+spec:
+  controlPlane:
+    count: 3
+    cpu: 4
+    memory: 8Gi
+    disk: 100Gi
+  workers:
+    count: 3
+    cpu: 8
+    memory: 32Gi
+    disk: 500Gi
+  network:
+    vlan: 40
+    subnet: 10.10.40.0/24
+```
+
+**Timeline:**
+- VM creation: ~5 minutes
+- Talos install: ~10 minutes
+- Cluster ready: ~15 minutes
+- **Total: ~30 minutes per cluster**
+
+**Result:**
+- Tenant cluster operational
+- Automatically registered with Argo CD
+- Applications deployed via GitOps
+
+---
+
+## Bootstrap Progression Diagram
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│                         PHASE 1: SEED (NAS)                             │
+│                                                                         │
+│  Step 1: Build VyOS Image (Packer)                                     │
+│           ↓                                                             │
+│  Step 2: Generate Talos Configs (talhelper)                            │
+│           ↓                                                             │
+│  Step 3: Create Seed Talos VM (NAS - 8GB RAM)                          │
+│           ↓                                                             │
+│  Step 4: Deploy Argo CD (Helm CLI)                                     │
+│           ↓                                                             │
+│  Step 5: Apply bootstrap Application → bootstrap/seed/                 │
+│           ↓                                                             │
+│  Step 6: Tinkerbell Deploys (Boots, Hegel, Rufio, Tink, NGINX)        │
+│           ↓                                                             │
+│  Step 7: VyOS Boots via PXE → Lab networking established              │
+│           ↓                                                             │
+│  Step 8: UM760 Boots via PXE → Talos installed → Joins cluster        │
+│                                                                         │
+│  Result: VyOS router online, 2-node cluster (NAS VM + UM760)           │
+└─────────────────────────────────────────────────────────────────────────┘
+                               ↓
+┌─────────────────────────────────────────────────────────────────────────┐
+│                  PHASE 2: SINGLE-NODE PLATFORM (UM760)                  │
+│                                                                         │
+│  Step 9: Migrate Workloads to UM760 (drain NAS)                        │
+│           ↓                                                             │
+│  Step 10: Delete bootstrap Application (remove seed manifests)         │
+│           ↓                                                             │
+│  Step 11: Apply Platform Configuration (clusters/platform/)            │
+│           → core.yaml (CoreServices XR)                                 │
+│           → platform.yaml (PlatformServices XR)                         │
+│           ↓                                                             │
+│  Step 12: Crossplane + Tinkerbell (XRD-based, permanent)               │
+│           ↓                                                             │
+│  Step 13: Provision Harvester (Tinkerbell PXE boots MS-02 nodes)       │
+│           → 3-node Harvester cluster online (~1.5 hours)                │
+│                                                                         │
+│  Result: Platform cluster (1 node), Harvester cluster (3 nodes)        │
+└─────────────────────────────────────────────────────────────────────────┘
+                               ↓
+┌─────────────────────────────────────────────────────────────────────────┐
+│                      PHASE 3: HARVESTER ONLINE                          │
+│                                                                         │
+│  Step 14: Register Harvester with Argo CD (cluster Secret)             │
+│           ↓                                                             │
+│  Step 15: Argo CD Syncs clusters/harvester/                            │
+│           → Networks (VLANs 10, 30, 40, 60)                             │
+│           → Images (Talos 1.9)                                          │
+│           → VMs (CP-2, CP-3)                                            │
+│           ↓                                                             │
+│  Step 16: CP-2, CP-3 VMs Created (powered off)                         │
+│           ↓                                                             │
+│  Step 17: CP-2, CP-3 PXE Boot → Talos installed → Join cluster        │
+│                                                                         │
+│  Result: Platform cluster (3 nodes HA), Harvester cluster (3 nodes)    │
+└─────────────────────────────────────────────────────────────────────────┘
+                               ↓
+┌─────────────────────────────────────────────────────────────────────────┐
+│                  PHASE 4: FULL PLATFORM (3-NODE HA)                     │
+│                                                                         │
+│  Step 18: Deploy Remaining Platform Services                           │
+│           → Observability (Prometheus, Grafana, Loki)                   │
+│           → CAPI providers (Harvester, Talos)                           │
+│           ↓                                                             │
+│  Step 19: Steady State - Validate all components healthy               │
+│           ↓                                                             │
+│  Step 20: Tenant Clusters - Provision via TenantCluster XR             │
+│           → media cluster (3 CP + 3 workers)                            │
+│           → dev cluster (1 CP + 2 workers)                              │
+│           → prod cluster (3 CP + 5 workers)                             │
+│                                                                         │
+│  Result: Full lab operational, ready for application workloads         │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Complete Step Reference
+
+| Phase | Step | Name | Duration | Purpose |
+|:------|:-----|:-----|:---------|:--------|
+| 1 | 1 | Build VyOS Image | 10 min | Create VyOS disk image with Packer |
+| 1 | 2 | Generate Talos Configs | 2 min | Create machine configs for all platform nodes |
+| 1 | 3 | Create Seed Talos VM | 15 min | Bootstrap initial Kubernetes cluster on NAS |
+| 1 | 4 | Deploy Argo CD | 5 min | Install GitOps controller |
+| 1 | 5 | Apply Bootstrap Application | 2 min | Deploy seed manifests (Tinkerbell, VyOS, UM760) |
+| 1 | 6 | Tinkerbell Deploys | 5 min | PXE services come online |
+| 1 | 7 | VyOS Boots via PXE | 6 min | Provision VyOS router, establish lab networking |
+| 1 | 8 | UM760 Boots via PXE | 10 min | Provision UM760 as first platform node |
+| 2 | 9 | Migrate Workloads to UM760 | 10 min | Move pods from NAS to UM760 |
+| 2 | 10 | Delete Bootstrap Application | 2 min | Remove temporary seed manifests |
+| 2 | 11 | Apply Platform Configuration | 5 min | Deploy CoreServices and PlatformServices XRs |
+| 2 | 12 | Crossplane + Tinkerbell (XRD) | 10 min | Redeploy Tinkerbell via XRs |
+| 2 | 13 | Provision Harvester | 90 min | PXE boot MS-02 nodes with Harvester OS |
+| 3 | 14 | Register Harvester with Argo CD | 5 min | Create cluster Secret for Harvester |
+| 3 | 15 | Argo CD Syncs clusters/harvester/ | 5 min | Deploy networks, images, VM definitions |
+| 3 | 16 | CP-2, CP-3 VMs Created | 5 min | Harvester creates VM resources |
+| 3 | 17 | CP-2, CP-3 PXE Boot | 20 min | Provision VMs with Talos, join platform cluster |
+| 4 | 18 | Deploy Remaining Platform Services | 15 min | Observability, CAPI providers |
+| 4 | 19 | Steady State | 10 min | Validate all components healthy |
+| 4 | 20 | Tenant Clusters | 30 min/cluster | Provision application workload clusters |
+
+**Total Duration (Phases 1-3):** ~3.5 hours
+**Phase 4:** Ongoing (as tenant clusters are added)
+
+---
+
+## Prerequisites
+
+Before beginning the bootstrap, ensure the following are in place:
+
+### Hardware
+
+| Component | Requirement | Purpose |
+|:----------|:------------|:--------|
+| **NAS** | Synology DS920+ or equivalent | Host seed Talos VM, store VyOS image |
+| **VP6630** | Minisforum VP6630 (VyOS router) | Lab gateway, VLAN routing, DHCP relay |
+| **UM760** | Minisforum UM760 (64GB RAM, 1TB SSD) | First platform node (bare-metal) |
+| **MS-02 (×3)** | Minisforum MS-02 (64GB RAM, 1TB NVMe each) | Harvester HCI cluster |
+| **Network** | Managed switch with VLAN support | Layer 2 switching, trunk ports |
+
+### Network
+
+| VLAN | Subnet | Purpose | DHCP |
+|:-----|:-------|:--------|:-----|
+| 10 | 10.10.10.0/24 | Management | Static IPs |
+| 20 | 10.10.20.0/24 | Services (NAS, DNS) | Static IPs |
+| 30 | 10.10.30.0/24 | Platform cluster | DHCP (Tinkerbell) |
+| 40 | 10.10.40.0/24 | Tenant clusters | DHCP (Tinkerbell) |
+| 60 | 10.10.60.0/24 | Storage replication | Static IPs |
+
+**Note:** VyOS is provisioned via Tinkerbell during bootstrap (Step 7). The Packer-built image includes:
+- VLANs configured and routing enabled
+- DHCP relay enabled for VLANs 30 and 40 (points to Tinkerbell)
+- DNS forwarding configured
+- NTP server configured
+
+### Software
+
+| Tool | Version | Purpose |
+|:-----|:--------|:--------|
+| Packer | v1.11.0+ | Build VyOS disk image |
+| talhelper | v3.0.0+ | Generate Talos machine configs |
+| SOPS | v3.9.0+ | Encrypt Talos secrets |
+| kubectl | v1.31.0+ | Kubernetes CLI |
+| Helm | v3.16.0+ | Install Argo CD |
+| talosctl | v1.9.0+ | Talos cluster management |
+
+### Credentials
+
+- **GitHub** - Personal access token with repo access (for Argo CD)
+- **SOPS** - Age key for encrypting/decrypting secrets
+- **NAS** - Admin credentials for VM creation
+- **Harvester** - Cluster token (generated during install)
+
+### Git Repository
+
+- Clone `https://github.com/gilmanlab/lab.git`
+- Checkout branch: `main` (or feature branch for testing)
+- Update `infrastructure/compute/talos/talconfig.yaml` with actual MAC addresses
+- Commit and push changes
+
+---
+
+## Post-Bootstrap State
+
+After completing all 18 steps, the lab infrastructure is in the following state:
+
+### Clusters
+
+| Cluster | Nodes | Purpose | State |
+|:--------|:------|:--------|:------|
+| **Platform** | 3 (CP-1, CP-2, CP-3) | Control plane, shared services | Operational |
+| **Harvester** | 3 (ms02-1, ms02-2, ms02-3) | HCI, VM hosting | Operational |
+| **Tenant** | 0 (ready for provisioning) | Application workloads | Ready |
+
+### Platform Cluster Details
+
+**Nodes:**
+
+| Node | Type | Hardware | IP (VLAN 30) | Role |
+|:-----|:-----|:---------|:-------------|:-----|
+| CP-1 | Bare-metal | UM760 | 10.10.30.10 | Control Plane + Worker |
+| CP-2 | VM | Harvester VM | 10.10.30.11 | Control Plane |
+| CP-3 | VM | Harvester VM | 10.10.30.12 | Control Plane |
+
+**Services Running:**
+
+| Service | Namespace | Purpose |
+|:--------|:----------|:--------|
+| Argo CD | argocd | GitOps controller |
+| Crossplane | crossplane-system | Infrastructure provisioning |
+| CAPI | capi-system | Cluster provisioning |
+| Tinkerbell | tinkerbell | PXE provisioning |
+| Istio | istio-system | Service mesh |
+| cert-manager | cert-manager | Certificate management |
+| external-dns | external-dns | DNS automation |
+| Zitadel | zitadel | Identity provider |
+| OpenBAO | openbao | Secrets management |
+| Vault Secrets Operator | vault-secrets-operator | Secret injection |
+| Prometheus | observability | Metrics collection |
+| Grafana | observability | Metrics visualization |
+| Loki | observability | Log aggregation |
+
+### Harvester Cluster Details
+
+**Nodes:**
+
+| Node | Hardware | IP (VLAN 10) | Storage | Role |
+|:-----|:---------|:-------------|:--------|:-----|
+| ms02-1 | MS-02 | 10.10.10.11 | 1TB NVMe | Control Plane + Compute |
+| ms02-2 | MS-02 | 10.10.10.12 | 1TB NVMe | Control Plane + Compute |
+| ms02-3 | MS-02 | 10.10.10.13 | 1TB NVMe | Control Plane + Compute |
+
+**Storage:**
+- Longhorn replicated storage (3 replicas across nodes)
+- Total capacity: ~2.7TB (3×1TB - overhead)
+
+**VMs Running:**
+
+| VM | vCPU | RAM | Disk | Network | Purpose |
+|:---|:-----|:----|:-----|:--------|:--------|
+| platform-cp-2 | 8 | 16GB | 100GB | VLAN 30 | Platform control plane node 2 |
+| platform-cp-3 | 8 | 16GB | 100GB | VLAN 30 | Platform control plane node 3 |
+
+### GitOps State
+
+**Argo CD Applications:**
+
+| Application | Path | Destination | Status |
+|:------------|:-----|:------------|:-------|
+| cluster-platform | clusters/platform/ | platform | Synced, Healthy |
+| platform-tinkerbell | clusters/platform/apps/tinkerbell/ | platform | Synced, Healthy |
+| platform-observability | clusters/platform/apps/observability/ | platform | Synced, Healthy |
+| platform-capi | clusters/platform/apps/capi/ | platform | Synced, Healthy |
+| cluster-harvester | clusters/harvester/ | harvester | Synced, Healthy |
+
+**Registered Clusters:**
+
+| Cluster | Server | Namespace | Label |
+|:--------|:-------|:----------|:------|
+| platform | https://kubernetes.default.svc | argocd | lab.gilman.io/cluster-name: platform |
+| harvester | https://10.10.10.11:6443 | argocd | lab.gilman.io/cluster-name: harvester |
+
+### Crossplane State
+
+**Installed Packages:**
+
+| Package | Version | Purpose |
+|:--------|:--------|:--------|
+| xrp-infrastructure | v1.0.0 | TenantCluster, Hardware, Workflow XRDs |
+| xrp-platform | v1.0.0 | CoreServices, PlatformServices, Application, Database XRDs |
+
+**XRDs Established:**
+
+| XRD | API Group | Kind |
+|:----|:----------|:-----|
+| TenantCluster | infrastructure.lab.gilman.io | TenantCluster |
+| Hardware | infrastructure.lab.gilman.io | Hardware |
+| Workflow | infrastructure.lab.gilman.io | Workflow |
+| CoreServices | platform.lab.gilman.io | CoreServices |
+| PlatformServices | platform.lab.gilman.io | PlatformServices |
+| Application | platform.lab.gilman.io | Application |
+| Database | platform.lab.gilman.io | Database |
+
+### Next Steps
+
+The platform is now ready for tenant cluster provisioning:
+
+1. Define tenant cluster in `clusters/<name>/cluster.yaml`
+2. Define core services in `clusters/<name>/core.yaml`
+3. Define applications in `clusters/<name>/apps/*/`
+4. Commit and push to Git
+5. Argo CD automatically syncs and provisions
+
+**Example workflow:**
+```bash
+# Create media cluster
+mkdir -p clusters/media/apps/plex
+cat > clusters/media/cluster.yaml <<EOF
+apiVersion: infrastructure.lab.gilman.io/v1alpha1
+kind: TenantCluster
+metadata:
+  name: media
+spec:
+  controlPlane:
+    count: 3
+    cpu: 4
+    memory: 8Gi
+  workers:
+    count: 3
+    cpu: 8
+    memory: 32Gi
+EOF
+
+git add clusters/media/
+git commit -m "Add media cluster"
+git push
+
+# Wait ~30 minutes for cluster to provision
+# Argo CD automatically registers cluster and deploys apps
+```
+
+---
+
+## Cross-References
+
+- [Appendix A: Repository Structure](A_repository_structure.md) - Directory layout and organization
+- [ADR-004: Platform Cluster Deployment](../09_design_decisions/ADR-004-platform-deployment.md) - Platform cluster architecture decisions
+- [Concept: Crossplane Abstractions](../08_concepts/crossplane-abstractions.md) - XRD design philosophy
+- [Deployment View](../07_deployment_view.md) - Physical and logical deployment architecture
+- [Building Block: Tinkerbell](../05_building_blocks/tinkerbell.md) - PXE provisioning system
+- [Building Block: Harvester](../05_building_blocks/harvester.md) - HCI platform
+- [Genesis Runbooks](../../bootstrap/genesis/README.md) - Step-by-step command execution guide

--- a/docs/architecture/appendices/C_argocd_configuration.md
+++ b/docs/architecture/appendices/C_argocd_configuration.md
@@ -1,0 +1,910 @@
+# Appendix C: Argo CD Configuration Reference
+
+> **Document Type**: Technical Reference
+> **Date**: 2025-12-19
+> **Related Concepts**: See main architecture documentation for high-level understanding
+
+This appendix provides detailed technical reference for Argo CD configuration in the lab infrastructure, including cluster registration, ApplicationSet definitions, sync wave strategies, and secrets management integration.
+
+---
+
+## Table of Contents
+
+- [Cluster Registration](#cluster-registration)
+- [ApplicationSet Definitions](#applicationset-definitions)
+- [Sync Wave Strategy](#sync-wave-strategy)
+- [Project Structure](#project-structure)
+- [Health Checks and Sync Policies](#health-checks-and-sync-policies)
+- [Secrets Management Integration](#secrets-management-integration)
+
+---
+
+## Cluster Registration
+
+Argo CD uses the Hub-and-Spoke model where a single Argo CD instance on the platform cluster manages all clusters. Clusters are registered via Secrets with the `argocd.argoproj.io/secret-type: cluster` label.
+
+### Platform Cluster Self-Registration
+
+The platform cluster must register itself to be managed by its own Argo CD instance. This registration happens during the initial bootstrap process.
+
+```yaml
+# File: Created during genesis (bootstrap/genesis/scripts/install-argocd.sh)
+# Location: platform cluster, argocd namespace
+# Purpose: Enables platform cluster to manage itself via Argo CD
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: platform
+  namespace: argocd
+  labels:
+    argocd.argoproj.io/secret-type: cluster
+    lab.gilman.io/cluster-name: platform
+type: Opaque
+stringData:
+  name: platform
+  server: https://kubernetes.default.svc
+  config: |
+    {
+      "tlsClientConfig": {
+        "insecure": false
+      }
+    }
+```
+
+**Key Points:**
+- Uses in-cluster endpoint (`https://kubernetes.default.svc`)
+- Created manually during bootstrap step
+- Required for ApplicationSets to target platform cluster
+- Label `lab.gilman.io/cluster-name: platform` enables ApplicationSet selector matching
+
+---
+
+### Harvester Cluster Registration
+
+Harvester is registered as a managed cluster after it is provisioned via Tinkerbell PXE boot. This registration is performed manually during bootstrap step 12.
+
+```yaml
+# File: Created manually during bootstrap step 12
+# Location: platform cluster, argocd namespace
+# Purpose: Enables Argo CD to manage Harvester infrastructure
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: harvester
+  namespace: argocd
+  labels:
+    argocd.argoproj.io/secret-type: cluster
+    lab.gilman.io/cluster-name: harvester
+type: Opaque
+stringData:
+  name: harvester
+  server: https://harvester.lab.local:6443
+  config: |
+    {
+      "tlsClientConfig": {
+        "caData": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0t...",
+        "certData": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0t...",
+        "keyData": "LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVkt..."
+      }
+    }
+```
+
+**How to Obtain Values:**
+```bash
+# Extract Harvester kubeconfig
+kubectl --kubeconfig /path/to/harvester.kubeconfig config view --raw -o json | \
+  jq -r '.clusters[0].cluster."certificate-authority-data"'  # caData
+
+kubectl --kubeconfig /path/to/harvester.kubeconfig config view --raw -o json | \
+  jq -r '.users[0].user."client-certificate-data"'  # certData
+
+kubectl --kubeconfig /path/to/harvester.kubeconfig config view --raw -o json | \
+  jq -r '.users[0].user."client-key-data"'  # keyData
+```
+
+**Key Points:**
+- Uses external endpoint (Harvester API server)
+- Requires TLS client certificates for authentication
+- Manages raw Harvester CRDs (networks, images, VMs)
+- Different from tenant clusters (which use Crossplane XRs)
+
+---
+
+### Tenant Cluster Automatic Registration
+
+Tenant clusters are automatically registered when their TenantCluster XR is created. The Crossplane composition includes logic to create the Argo CD cluster Secret with the CAPI-generated kubeconfig.
+
+```yaml
+# File: Automatically created by TenantCluster XR composition
+# Location: platform cluster, argocd namespace
+# Purpose: Enables Argo CD to immediately discover and deploy to new tenant cluster
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: media
+  namespace: argocd
+  labels:
+    argocd.argoproj.io/secret-type: cluster
+    lab.gilman.io/cluster-name: media
+    lab.gilman.io/cluster-type: tenant
+    lab.gilman.io/managed-by: crossplane
+type: Opaque
+stringData:
+  name: media
+  server: https://10.10.40.10:6443
+  config: |
+    {
+      "tlsClientConfig": {
+        "caData": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0t...",
+        "certData": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0t...",
+        "keyData": "LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVkt..."
+      }
+    }
+```
+
+**TenantCluster XR Composition Logic (Conceptual):**
+```yaml
+# Within the TenantCluster XRD composition
+# This shows the concept - actual implementation uses Crossplane Functions
+
+resources:
+  # ... CAPI Cluster resources ...
+
+  # Argo CD cluster registration Secret
+  - name: argocd-cluster-secret
+    base:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        namespace: argocd
+        labels:
+          argocd.argoproj.io/secret-type: cluster
+          lab.gilman.io/cluster-type: tenant
+          lab.gilman.io/managed-by: crossplane
+      type: Opaque
+    patches:
+      - type: FromCompositeFieldPath
+        fromFieldPath: metadata.name
+        toFieldPath: metadata.name
+      - type: FromCompositeFieldPath
+        fromFieldPath: metadata.name
+        toFieldPath: stringData.name
+      - type: FromCompositeFieldPath
+        fromFieldPath: status.controlPlaneEndpoint
+        toFieldPath: stringData.server
+        transforms:
+          - type: string
+            string:
+              fmt: "https://%s:6443"
+      - type: FromCompositeFieldPath
+        fromFieldPath: status.kubeconfig
+        toFieldPath: stringData.config
+```
+
+**Key Points:**
+- Fully automated - no manual intervention required
+- Created as soon as CAPI generates kubeconfig
+- Enables immediate deployment of apps to new cluster
+- Lifecycle tied to TenantCluster XR (deleted when XR is deleted)
+
+---
+
+## ApplicationSet Definitions
+
+### cluster-definitions ApplicationSet
+
+This ApplicationSet syncs cluster-level configuration files (`cluster.yaml`, `core.yaml`, `platform.yaml`) to the **platform cluster** where Crossplane processes the XR Claims.
+
+```yaml
+# File: clusters/platform/apps/argocd/applicationsets/cluster-definitions.yaml
+# Purpose: Deploy cluster definitions as XR Claims to platform cluster for Crossplane to process
+
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: cluster-definitions
+  namespace: argocd
+spec:
+  goTemplate: true
+  goTemplateOptions: ["missingkey=error"]
+
+  generators:
+    - git:
+        repoURL: https://github.com/gilmanlab/lab.git
+        revision: HEAD
+        directories:
+          - path: clusters/*
+            exclude: false
+
+  template:
+    metadata:
+      name: 'cluster-{{.path.basename}}'
+      annotations:
+        argocd.argoproj.io/manifest-generate-paths: '{{.path}}'
+      labels:
+        app.kubernetes.io/managed-by: argocd
+        lab.gilman.io/cluster-name: '{{.path.basename}}'
+        lab.gilman.io/app-type: cluster-definition
+
+    spec:
+      project: clusters
+
+      # Always deploy to platform cluster - Crossplane lives here
+      destination:
+        server: https://kubernetes.default.svc
+        namespace: default
+
+      source:
+        repoURL: https://github.com/gilmanlab/lab.git
+        targetRevision: HEAD
+        path: '{{.path}}'
+        directory:
+          recurse: false
+          include: '*.yaml'
+          exclude: 'apps/**'
+
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+          allowEmpty: false
+        syncOptions:
+          - CreateNamespace=true
+          - ServerSideApply=true
+          - RespectIgnoreDifferences=true
+        retry:
+          limit: 5
+          backoff:
+            duration: 5s
+            factor: 2
+            maxDuration: 3m
+
+      ignoreDifferences:
+        - group: "*"
+          kind: "*"
+          jqPathExpressions:
+            - '.metadata.managedFields'
+```
+
+**What This Creates:**
+
+| Cluster Directory | Application Name | Contains | Deployed To |
+|:---|:---|:---|:---|
+| `clusters/platform/` | `cluster-platform` | `core.yaml`, `platform.yaml` | Platform cluster |
+| `clusters/harvester/` | `cluster-harvester` | (none - uses `config/` and `vms/`) | Platform cluster |
+| `clusters/media/` | `cluster-media` | `cluster.yaml`, `core.yaml` | Platform cluster |
+| `clusters/dev/` | `cluster-dev` | `cluster.yaml`, `core.yaml` | Platform cluster |
+| `clusters/prod/` | `cluster-prod` | `cluster.yaml`, `core.yaml` | Platform cluster |
+
+**Key Configuration Details:**
+- `recurse: false` - Only files in cluster root directory, not subdirectories
+- `include: '*.yaml'` - Only YAML files
+- `exclude: 'apps/**'` - Explicitly exclude apps subdirectory
+- `ServerSideApply=true` - Required for proper Crossplane field management
+- Always targets `https://kubernetes.default.svc` (platform cluster)
+
+---
+
+### cluster-apps ApplicationSet
+
+This ApplicationSet uses a matrix generator to deploy applications to their correct destination clusters. It combines cluster discovery with git directory discovery.
+
+```yaml
+# File: clusters/platform/apps/argocd/applicationsets/cluster-apps.yaml
+# Purpose: Deploy applications from clusters/*/apps/* to their respective target clusters
+
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: cluster-apps
+  namespace: argocd
+spec:
+  goTemplate: true
+  goTemplateOptions: ["missingkey=error"]
+
+  generators:
+    - matrix:
+        generators:
+          # Generator 1: Discover all registered clusters
+          - clusters:
+              selector:
+                matchExpressions:
+                  - key: lab.gilman.io/cluster-name
+                    operator: Exists
+              values:
+                clusterName: '{{.name}}'
+
+          # Generator 2: For each cluster, discover its app directories
+          - git:
+              repoURL: https://github.com/gilmanlab/lab.git
+              revision: HEAD
+              directories:
+                - path: 'clusters/{{.values.clusterName}}/apps/*'
+
+  template:
+    metadata:
+      name: '{{.values.clusterName}}-{{.path.basename}}'
+      annotations:
+        argocd.argoproj.io/manifest-generate-paths: '{{.path}}'
+      labels:
+        app.kubernetes.io/managed-by: argocd
+        lab.gilman.io/cluster-name: '{{.values.clusterName}}'
+        lab.gilman.io/app-name: '{{.path.basename}}'
+        lab.gilman.io/app-type: application
+
+    spec:
+      project: apps
+
+      # Deploy to actual cluster (uses server from cluster Secret)
+      destination:
+        server: '{{.server}}'
+        namespace: default
+
+      source:
+        repoURL: https://github.com/gilmanlab/lab.git
+        targetRevision: HEAD
+        path: '{{.path}}'
+        directory:
+          recurse: true
+          include: '*.yaml'
+
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+          allowEmpty: false
+        syncOptions:
+          - CreateNamespace=true
+          - ServerSideApply=true
+          - RespectIgnoreDifferences=true
+        retry:
+          limit: 5
+          backoff:
+            duration: 5s
+            factor: 2
+            maxDuration: 3m
+
+      ignoreDifferences:
+        - group: "*"
+          kind: "*"
+          jqPathExpressions:
+            - '.metadata.managedFields'
+```
+
+**Matrix Generator Flow:**
+
+```
+Step 1: Cluster Generator discovers registered clusters
+  → platform (server: https://kubernetes.default.svc)
+  → harvester (server: https://harvester.lab.local:6443)
+  → media (server: https://10.10.40.10:6443)
+  → dev (server: https://10.10.40.20:6443)
+
+Step 2: For each cluster, Git Generator discovers apps
+  → clusters/platform/apps/tinkerbell/
+  → clusters/platform/apps/observability/
+  → clusters/platform/apps/capi/
+  → clusters/media/apps/plex/
+  → clusters/media/apps/jellyfin/
+  → (etc.)
+
+Step 3: Matrix combines them
+  → platform-tinkerbell (deployed to platform cluster)
+  → platform-observability (deployed to platform cluster)
+  → media-plex (deployed to media cluster)
+  → media-jellyfin (deployed to media cluster)
+  → (etc.)
+```
+
+**Example Generated Application:**
+
+```yaml
+# Generated for clusters/media/apps/plex/
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: media-plex
+  namespace: argocd
+  labels:
+    lab.gilman.io/cluster-name: media
+    lab.gilman.io/app-name: plex
+    lab.gilman.io/app-type: application
+spec:
+  project: apps
+  destination:
+    server: https://10.10.40.10:6443  # From media cluster Secret
+    namespace: default
+  source:
+    repoURL: https://github.com/gilmanlab/lab.git
+    targetRevision: HEAD
+    path: clusters/media/apps/plex
+    directory:
+      recurse: true
+```
+
+**Key Configuration Details:**
+- Matrix generator enables many-to-many mapping
+- `recurse: true` - Include all files in app directory tree
+- Destination server comes from cluster Secret (`{{.server}}`)
+- Each cluster only gets its own apps (path filtering via `clusterName`)
+
+---
+
+## Sync Wave Strategy
+
+Argo CD sync waves control the order in which resources are deployed. This ensures dependencies are satisfied before dependent resources are created.
+
+### Sync Wave Ordering
+
+| Wave | Resource Type | Example | Rationale |
+|:---:|:---|:---|:---|
+| `-5` | Namespaces | Namespace CRDs | Must exist before other resources |
+| `-4` | CRDs and XRDs | Crossplane XRDs, CAPI CRDs | Define custom resource types |
+| `-3` | Operators | Crossplane, CAPI providers, cert-manager | Process custom resources |
+| `-2` | Configurations | Crossplane Configurations, provider configs | Configure operators |
+| `-1` | XR Claims (Infrastructure) | CoreServices XR, PlatformServices XR | Core infrastructure layer |
+| `0` | XR Claims (Clusters) | TenantCluster XR | Cluster provisioning |
+| `1` | XR Claims (Apps) | Application XR, Database XR | Application-level resources |
+| `2` | Post-deployment | Backup jobs, monitoring alerts | Depends on apps being ready |
+
+### Implementation Examples
+
+**CoreServices XR (Wave -1):**
+```yaml
+# File: clusters/platform/core.yaml
+# Purpose: Deploy foundational platform services before anything else
+
+apiVersion: platform.gilman.io/v1alpha1
+kind: CoreServices
+metadata:
+  name: platform
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+    argocd.argoproj.io/sync-options: "SkipDryRunOnMissingResource=true"
+spec:
+  crossplane:
+    version: "1.14.5"
+    providers:
+      - provider-kubernetes
+      - provider-helm
+  certManager:
+    version: "1.13.3"
+  capi:
+    version: "1.6.1"
+    providers:
+      - harvester
+      - talos
+```
+
+**TenantCluster XR (Wave 0):**
+```yaml
+# File: clusters/media/cluster.yaml
+# Purpose: Provision tenant cluster after core services are ready
+
+apiVersion: infrastructure.gilman.io/v1alpha1
+kind: TenantCluster
+metadata:
+  name: media
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+    argocd.argoproj.io/sync-options: "SkipDryRunOnMissingResource=true"
+spec:
+  controlPlane:
+    replicas: 3
+    machineType: "standard-medium"
+  workers:
+    replicas: 3
+    machineType: "standard-large"
+  network:
+    vlan: 40
+    subnet: "10.10.40.0/24"
+  talos:
+    version: "1.9.0"
+```
+
+**Application XR (Wave 1):**
+```yaml
+# File: clusters/media/apps/plex/plex.yaml
+# Purpose: Deploy application after cluster exists
+
+apiVersion: platform.gilman.io/v1alpha1
+kind: Application
+metadata:
+  name: plex
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  chart:
+    repository: https://charts.example.com
+    name: plex
+    version: "1.2.3"
+  values:
+    persistence:
+      enabled: true
+      size: "500Gi"
+```
+
+### Wave Progression Flow
+
+```
+Wave -5: Namespaces created
+    ↓
+Wave -4: XRDs and CRDs installed
+    ↓
+Wave -3: Operators deployed (Crossplane, CAPI)
+    ↓ (Wait for operators to be ready)
+Wave -2: Provider configurations applied
+    ↓
+Wave -1: CoreServices XR processed
+    ↓ (Crossplane deploys cert-manager, etc.)
+Wave 0: TenantCluster XR processed
+    ↓ (CAPI provisions VMs, creates cluster)
+Wave 1: Application XR processed
+    ↓ (Apps deployed to tenant cluster)
+Wave 2: Post-deployment resources
+```
+
+**Sync Options:**
+- `SkipDryRunOnMissingResource=true` - Required for XRs (CRD may not exist yet)
+- `RespectIgnoreDifferences=true` - Prevent sync loops on Crossplane-managed fields
+
+---
+
+## Project Structure
+
+Argo CD Projects provide logical grouping and RBAC boundaries for applications.
+
+### clusters Project
+
+```yaml
+# File: clusters/platform/apps/argocd/projects/clusters.yaml
+# Purpose: Project for cluster definition applications
+
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: clusters
+  namespace: argocd
+spec:
+  description: Cluster definitions (XR Claims for infrastructure)
+
+  sourceRepos:
+    - https://github.com/gilmanlab/lab.git
+
+  # Cluster definitions always deploy to platform cluster
+  destinations:
+    - server: https://kubernetes.default.svc
+      namespace: '*'
+
+  # Allow all Crossplane XR types
+  clusterResourceWhitelist:
+    - group: 'infrastructure.gilman.io'
+      kind: '*'
+    - group: 'platform.gilman.io'
+      kind: '*'
+
+  namespaceResourceWhitelist:
+    - group: '*'
+      kind: '*'
+
+  orphanedResources:
+    warn: true
+```
+
+### apps Project
+
+```yaml
+# File: clusters/platform/apps/argocd/projects/apps.yaml
+# Purpose: Project for application deployments across all clusters
+
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: apps
+  namespace: argocd
+spec:
+  description: Application deployments to managed clusters
+
+  sourceRepos:
+    - https://github.com/gilmanlab/lab.git
+
+  # Apps can deploy to any registered cluster
+  destinations:
+    - server: '*'
+      namespace: '*'
+
+  # Allow Application XRs and Helm releases
+  clusterResourceWhitelist:
+    - group: 'platform.gilman.io'
+      kind: 'Application'
+    - group: 'platform.gilman.io'
+      kind: 'Database'
+
+  namespaceResourceWhitelist:
+    - group: '*'
+      kind: '*'
+
+  orphanedResources:
+    warn: true
+```
+
+### harvester Project
+
+```yaml
+# File: clusters/platform/apps/argocd/projects/harvester.yaml
+# Purpose: Project for Harvester infrastructure resources
+
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  name: harvester
+  namespace: argocd
+spec:
+  description: Harvester HCI cluster configuration
+
+  sourceRepos:
+    - https://github.com/gilmanlab/lab.git
+
+  # Only deploy to Harvester cluster
+  destinations:
+    - server: https://harvester.lab.local:6443
+      namespace: '*'
+
+  # Allow Harvester-specific CRDs
+  clusterResourceWhitelist:
+    - group: 'network.harvesterhci.io'
+      kind: '*'
+    - group: 'kubevirt.io'
+      kind: '*'
+
+  namespaceResourceWhitelist:
+    - group: '*'
+      kind: '*'
+
+  orphanedResources:
+    warn: true
+```
+
+---
+
+## Health Checks and Sync Policies
+
+### Custom Health Checks
+
+Argo CD needs custom health checks to understand Crossplane XR status.
+
+```yaml
+# File: clusters/platform/apps/argocd/config/argocd-cm.yaml
+# Purpose: Configure custom health checks for Crossplane resources
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-cm
+  namespace: argocd
+data:
+  # Custom health check for Crossplane XRs
+  resource.customizations.health.infrastructure.gilman.io_TenantCluster: |
+    hs = {}
+    if obj.status ~= nil then
+      if obj.status.conditions ~= nil then
+        for i, condition in ipairs(obj.status.conditions) do
+          if condition.type == "Ready" then
+            if condition.status == "True" then
+              hs.status = "Healthy"
+              hs.message = "Cluster is ready"
+              return hs
+            elseif condition.status == "False" then
+              hs.status = "Degraded"
+              hs.message = condition.message
+              return hs
+            end
+          end
+        end
+      end
+    end
+    hs.status = "Progressing"
+    hs.message = "Waiting for cluster to be ready"
+    return hs
+
+  # Custom health check for CAPI Clusters
+  resource.customizations.health.cluster.x-k8s.io_Cluster: |
+    hs = {}
+    if obj.status ~= nil then
+      if obj.status.phase == "Provisioned" then
+        hs.status = "Healthy"
+        hs.message = "Cluster is provisioned"
+        return hs
+      elseif obj.status.phase == "Failed" then
+        hs.status = "Degraded"
+        hs.message = "Cluster provisioning failed"
+        return hs
+      end
+    end
+    hs.status = "Progressing"
+    hs.message = "Cluster is provisioning"
+    return hs
+```
+
+### Global Sync Policies
+
+```yaml
+# File: clusters/platform/apps/argocd/config/argocd-cm.yaml (continued)
+# Purpose: Set default sync policies for all applications
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-cm
+  namespace: argocd
+data:
+  # (health checks above)
+
+  # Global sync options
+  application.resourceTrackingMethod: annotation+label
+
+  # Timeout for sync operations
+  timeout.reconciliation: 300s
+  timeout.hard.reconciliation: 0
+
+  # Resource exclusions (don't manage these)
+  resource.exclusions: |
+    - apiGroups:
+      - cilium.io
+      kinds:
+      - CiliumIdentity
+      clusters:
+      - "*"
+```
+
+---
+
+## Secrets Management Integration
+
+The lab uses Vault Secrets Operator (VSO) for injecting secrets into XR Claims and applications.
+
+### VSO Configuration
+
+VSO is deployed as part of the CoreServices XR and integrates with OpenBAO (deployed via PlatformServices XR).
+
+```yaml
+# File: Part of CoreServices XR composition
+# Purpose: Deploy VSO to enable secret injection
+
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: vault-secrets-operator
+  namespace: vault-secrets-operator-system
+spec:
+  chart:
+    spec:
+      chart: vault-secrets-operator
+      version: "0.4.3"
+      sourceRef:
+        kind: HelmRepository
+        name: hashicorp
+  values:
+    defaultVaultConnection:
+      enabled: true
+      address: "http://openbao.openbao-system.svc:8200"
+      skipTLSVerify: false
+```
+
+### Secret Injection in XR Claims
+
+**Example: Database XR with VSO Secret Injection**
+
+```yaml
+# File: clusters/media/apps/plex/database.yaml
+# Purpose: Provision PostgreSQL database with credentials from Vault
+
+apiVersion: platform.gilman.io/v1alpha1
+kind: Database
+metadata:
+  name: plex-db
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"  # Before Application XR
+spec:
+  engine: postgresql
+  version: "16"
+  size: "20Gi"
+
+  # VSO injects credentials from Vault
+  credentialsSecretRef:
+    name: plex-db-credentials
+
+---
+# VSO VaultStaticSecret - fetches from Vault and creates K8s Secret
+apiVersion: secrets.hashicorp.com/v1beta1
+kind: VaultStaticSecret
+metadata:
+  name: plex-db-credentials
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"  # Before Database XR
+spec:
+  vaultAuthRef: default
+  mount: kv
+  type: kv-v2
+  path: databases/plex/credentials
+
+  destination:
+    name: plex-db-credentials
+    create: true
+
+  refreshAfter: 30s
+
+  # Secret mapping
+  hmacSecretData: true
+```
+
+**Vault Secret Structure:**
+```bash
+# In OpenBAO/Vault at path: kv/databases/plex/credentials
+{
+  "username": "plex_user",
+  "password": "randomly-generated-secure-password",
+  "database": "plex"
+}
+```
+
+### VSO in ApplicationSets
+
+VSO is also used by ApplicationSets to inject cluster-specific secrets:
+
+```yaml
+# File: clusters/platform/apps/argocd/vso/cluster-secrets.yaml
+# Purpose: Create VaultStaticSecrets for each cluster's sensitive configuration
+
+apiVersion: secrets.hashicorp.com/v1beta1
+kind: VaultStaticSecret
+metadata:
+  name: media-cluster-secrets
+  namespace: argocd
+spec:
+  vaultAuthRef: default
+  mount: kv
+  type: kv-v2
+  path: clusters/media/secrets
+
+  destination:
+    name: media-cluster-secrets
+    create: true
+
+  # Used by Applications deployed to media cluster
+  labels:
+    lab.gilman.io/cluster-name: media
+```
+
+**Benefits of VSO Integration:**
+- Secrets stored in Vault, not in Git
+- Automatic rotation and refresh
+- Audit trail of secret access
+- Centralized secret management
+- No plaintext secrets in repository
+
+---
+
+## Summary Table
+
+| Component | Purpose | Key Features |
+|:---|:---|:---|
+| **Cluster Registration** | Enable Argo CD to manage multiple clusters | Platform self-registration, Harvester manual, tenant automatic via XR |
+| **cluster-definitions ApplicationSet** | Deploy XR Claims to platform cluster | Git directory discovery, platform-targeted |
+| **cluster-apps ApplicationSet** | Deploy apps to correct clusters | Matrix generator, multi-cluster routing |
+| **Sync Waves** | Control deployment order | -5 to +2, ensures dependencies |
+| **Projects** | Logical grouping and RBAC | clusters, apps, harvester projects |
+| **Health Checks** | Custom Crossplane/CAPI status | Lua-based health assessment |
+| **VSO Integration** | Secret management | Vault-backed, auto-rotation, no Git secrets |
+
+---
+
+## References
+
+- See main architecture documentation for high-level concepts
+- See Appendix D for Harvester-specific configuration
+- Argo CD ApplicationSet documentation: https://argo-cd.readthedocs.io/en/stable/user-guide/application-set/
+- Vault Secrets Operator: https://github.com/hashicorp/vault-secrets-operator

--- a/docs/architecture/appendices/D_harvester_configuration.md
+++ b/docs/architecture/appendices/D_harvester_configuration.md
@@ -1,0 +1,975 @@
+# Appendix D: Harvester Configuration Reference
+
+> **Document Type**: Technical Reference
+> **Date**: 2025-12-19
+> **Related Concepts**: See main architecture documentation for high-level understanding
+
+This appendix provides detailed technical reference for Harvester HCI cluster configuration, including network setup, image management, virtual machine definitions, storage configuration, and integration with Cluster API.
+
+---
+
+## Table of Contents
+
+- [Network Configuration](#network-configuration)
+- [Image Management](#image-management)
+- [Virtual Machine Definitions](#virtual-machine-definitions)
+- [Storage Configuration](#storage-configuration)
+- [Integration with CAPI](#integration-with-capi)
+
+---
+
+## Network Configuration
+
+Harvester uses ClusterNetwork and VlanConfig CRDs to configure VLAN-backed networks for VM connectivity. These networks map to the physical VLANs configured on the VyOS gateway.
+
+### Network Architecture Overview
+
+| VLAN ID | Network Name | Subnet | Purpose | Used By |
+|:---:|:---|:---|:---|:---|
+| 10 | `mgmt` | 10.10.10.0/24 | Management | Harvester nodes, BMC, switches |
+| 30 | `platform` | 10.10.30.0/24 | Platform cluster | Platform CP-2, CP-3 VMs |
+| 40 | `cluster` | 10.10.40.0/24 | Tenant clusters | CAPI-provisioned tenant cluster VMs |
+| 60 | `storage` | 10.10.60.0/24 | Storage replication | Longhorn inter-node replication |
+
+### ClusterNetwork CRDs
+
+ClusterNetwork CRDs define the physical network configuration in Harvester.
+
+#### Management Network (VLAN 10)
+
+```yaml
+# File: clusters/harvester/config/networks/mgmt.yaml
+# Purpose: Management network for Harvester nodes and infrastructure
+
+apiVersion: network.harvesterhci.io/v1beta1
+kind: ClusterNetwork
+metadata:
+  name: mgmt
+  annotations:
+    argocd.argoproj.io/sync-wave: "-3"
+    network.harvesterhci.io/description: "Management network for infrastructure"
+spec:
+  description: "VLAN 10 - Management Network"
+
+  # Enable VLAN support
+  enable: true
+
+  # Default network for Harvester management traffic
+  defaultNetwork: true
+
+---
+apiVersion: network.harvesterhci.io/v1beta1
+kind: VlanConfig
+metadata:
+  name: mgmt-vlan
+  annotations:
+    argocd.argoproj.io/sync-wave: "-3"
+spec:
+  clusterNetwork: mgmt
+  vlan: 10
+  uplink:
+    bondOptions:
+      mode: active-backup
+      miimon: 100
+    linkAttributes:
+      mtu: 1500
+      txQueueLen: 1000
+    nics:
+      - enp2s0  # Primary NIC on MS-02 nodes
+```
+
+#### Platform Cluster Network (VLAN 30)
+
+```yaml
+# File: clusters/harvester/config/networks/platform.yaml
+# Purpose: Network for platform cluster control plane VMs
+
+apiVersion: network.harvesterhci.io/v1beta1
+kind: ClusterNetwork
+metadata:
+  name: platform
+  annotations:
+    argocd.argoproj.io/sync-wave: "-3"
+    network.harvesterhci.io/description: "Platform cluster control plane network"
+spec:
+  description: "VLAN 30 - Platform Cluster Network"
+  enable: true
+  defaultNetwork: false
+
+---
+apiVersion: network.harvesterhci.io/v1beta1
+kind: VlanConfig
+metadata:
+  name: platform-vlan
+  annotations:
+    argocd.argoproj.io/sync-wave: "-3"
+spec:
+  clusterNetwork: platform
+  vlan: 30
+  uplink:
+    bondOptions:
+      mode: active-backup
+      miimon: 100
+    linkAttributes:
+      mtu: 1500
+      txQueueLen: 1000
+    nics:
+      - enp2s0
+```
+
+#### Tenant Cluster Network (VLAN 40)
+
+```yaml
+# File: clusters/harvester/config/networks/cluster.yaml
+# Purpose: Network for CAPI-provisioned tenant cluster VMs
+
+apiVersion: network.harvesterhci.io/v1beta1
+kind: ClusterNetwork
+metadata:
+  name: cluster
+  annotations:
+    argocd.argoproj.io/sync-wave: "-3"
+    network.harvesterhci.io/description: "Tenant cluster VM network"
+spec:
+  description: "VLAN 40 - Tenant Cluster Network"
+  enable: true
+  defaultNetwork: false
+
+---
+apiVersion: network.harvesterhci.io/v1beta1
+kind: VlanConfig
+metadata:
+  name: cluster-vlan
+  annotations:
+    argocd.argoproj.io/sync-wave: "-3"
+spec:
+  clusterNetwork: cluster
+  vlan: 40
+  uplink:
+    bondOptions:
+      mode: active-backup
+      miimon: 100
+    linkAttributes:
+      mtu: 9000  # Jumbo frames for better performance
+      txQueueLen: 1000
+    nics:
+      - enp2s0
+```
+
+#### Storage Replication Network (VLAN 60)
+
+```yaml
+# File: clusters/harvester/config/networks/storage.yaml
+# Purpose: Dedicated network for Longhorn storage replication
+
+apiVersion: network.harvesterhci.io/v1beta1
+kind: ClusterNetwork
+metadata:
+  name: storage
+  annotations:
+    argocd.argoproj.io/sync-wave: "-3"
+    network.harvesterhci.io/description: "Longhorn storage replication network"
+spec:
+  description: "VLAN 60 - Storage Replication Network"
+  enable: true
+  defaultNetwork: false
+
+---
+apiVersion: network.harvesterhci.io/v1beta1
+kind: VlanConfig
+metadata:
+  name: storage-vlan
+  annotations:
+    argocd.argoproj.io/sync-wave: "-3"
+spec:
+  clusterNetwork: storage
+  vlan: 60
+  uplink:
+    bondOptions:
+      mode: active-backup
+      miimon: 100
+    linkAttributes:
+      mtu: 9000  # Jumbo frames for storage traffic
+      txQueueLen: 1000
+    nics:
+      - enp3s0  # Dedicated NIC for storage (if available)
+```
+
+### VLAN to VM Network Mapping
+
+When creating VirtualMachine CRDs, networks are referenced by ClusterNetwork name:
+
+| VM Type | Primary Network | Secondary Networks | IP Assignment |
+|:---|:---|:---|:---|
+| Harvester nodes | `mgmt` (VLAN 10) | `storage` (VLAN 60) | DHCP (management), Static (storage) |
+| Platform CP-2, CP-3 | `platform` (VLAN 30) | - | Static via cloud-init |
+| Tenant cluster VMs (CAPI) | `cluster` (VLAN 40) | - | Static via CAPI |
+| Standalone VMs | `mgmt` (VLAN 10) | As needed | DHCP or Static |
+
+---
+
+## Image Management
+
+Harvester uses VirtualMachineImage CRDs to manage VM disk images. These images can be imported from URLs, uploaded directly, or built from ISOs.
+
+### Talos VM Image
+
+The Talos image is used for both platform cluster VMs and CAPI-provisioned tenant cluster VMs.
+
+```yaml
+# File: clusters/harvester/config/images/talos-1.9.yaml
+# Purpose: Talos Linux disk image for Kubernetes nodes
+
+apiVersion: harvesterhci.io/v1beta1
+kind: VirtualMachineImage
+metadata:
+  name: talos-1.9.0
+  namespace: default
+  annotations:
+    argocd.argoproj.io/sync-wave: "-2"
+    harvesterhci.io/image-type: "os"
+  labels:
+    harvesterhci.io/os: linux
+    harvesterhci.io/os-version: talos-1.9.0
+spec:
+  displayName: "Talos Linux 1.9.0"
+  description: "Talos Linux v1.9.0 - Immutable Kubernetes OS"
+
+  # Source URL for image download
+  sourceType: download
+  url: "https://github.com/siderolabs/talos/releases/download/v1.9.0/nocloud-amd64.raw.xz"
+
+  # Image will be stored in Longhorn
+  storageClassName: longhorn
+
+  # Optional: Checksum verification
+  checksum: "sha256:a1b2c3d4e5f6..."
+
+  # PVC settings
+  pvcName: talos-1.9.0-image
+  pvcNamespace: default
+
+  # Size will be determined from image
+  # (Talos images are typically ~150MB compressed, ~1GB uncompressed)
+```
+
+**Image Download Process:**
+1. Harvester creates a PVC with the specified StorageClass
+2. Harvester launches an importer Pod to download the image
+3. Image is decompressed and written to PVC
+4. PVC becomes available as a disk image for VMs
+5. VMs can clone this image for their root disks
+
+### Additional Image Examples
+
+**Ubuntu Cloud Image (for standalone VMs):**
+
+```yaml
+# File: clusters/harvester/config/images/ubuntu-22.04.yaml
+# Purpose: Ubuntu Server cloud image for general-purpose VMs
+
+apiVersion: harvesterhci.io/v1beta1
+kind: VirtualMachineImage
+metadata:
+  name: ubuntu-22.04
+  namespace: default
+  annotations:
+    argocd.argoproj.io/sync-wave: "-2"
+  labels:
+    harvesterhci.io/os: linux
+    harvesterhci.io/os-version: ubuntu-22.04
+spec:
+  displayName: "Ubuntu 22.04 LTS"
+  description: "Ubuntu Server 22.04 LTS (Jammy Jellyfish)"
+  sourceType: download
+  url: "https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img"
+  storageClassName: longhorn
+  pvcName: ubuntu-22.04-image
+  pvcNamespace: default
+```
+
+**Windows Server (for standalone VMs):**
+
+```yaml
+# File: clusters/harvester/config/images/windows-server-2022.yaml
+# Purpose: Windows Server image (requires manual upload)
+
+apiVersion: harvesterhci.io/v1beta1
+kind: VirtualMachineImage
+metadata:
+  name: windows-server-2022
+  namespace: default
+  annotations:
+    argocd.argoproj.io/sync-wave: "-2"
+  labels:
+    harvesterhci.io/os: windows
+    harvesterhci.io/os-version: windows-server-2022
+spec:
+  displayName: "Windows Server 2022"
+  description: "Windows Server 2022 Datacenter"
+
+  # Upload type requires manual web UI upload or PVC creation
+  sourceType: upload
+  storageClassName: longhorn
+  pvcName: windows-server-2022-image
+  pvcNamespace: default
+```
+
+---
+
+## Virtual Machine Definitions
+
+Harvester uses KubeVirt VirtualMachine CRDs to define virtual machines. These VMs are managed directly via Argo CD for platform bootstrap and standalone workloads.
+
+### VM Categories in Harvester
+
+| Directory | Purpose | Lifecycle | Provisioned By |
+|:---|:---|:---|:---|
+| `vms/platform/` | Platform cluster CP-2, CP-3 nodes | Bootstrap only, deleted after CAPI migration | Argo CD → Harvester |
+| `vms/standalone/` | Non-containerized workloads | Permanent | Argo CD → Harvester |
+| (Not in repo) | Tenant cluster VMs | Dynamic, CAPI-managed | Crossplane XR → CAPI → Harvester |
+
+### Platform CP-2 VM Definition
+
+This VM is created during bootstrap phase 3 to expand the platform cluster from single-node (UM760) to multi-node HA.
+
+```yaml
+# File: clusters/harvester/vms/platform/cp-2.yaml
+# Purpose: Platform cluster control plane node 2 (Harvester VM)
+
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: platform-cp-2
+  namespace: default
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+    harvesterhci.io/description: "Platform cluster control plane node 2"
+  labels:
+    harvesterhci.io/cluster: platform
+    harvesterhci.io/node-role: control-plane
+    harvesterhci.io/os: talos
+spec:
+  running: true
+
+  template:
+    metadata:
+      labels:
+        kubevirt.io/vm: platform-cp-2
+        harvesterhci.io/cluster: platform
+        harvesterhci.io/node-role: control-plane
+
+    spec:
+      # Node affinity - prefer spreading across Harvester nodes
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: harvesterhci.io/cluster
+                      operator: In
+                      values:
+                        - platform
+                topologyKey: kubernetes.io/hostname
+
+      # Resource allocation
+      domain:
+        cpu:
+          cores: 4
+          sockets: 1
+          threads: 1
+
+        memory:
+          guest: 16Gi
+
+        # Devices
+        devices:
+          disks:
+            - name: rootdisk
+              bootOrder: 1
+              disk:
+                bus: virtio
+            - name: cloudinitdisk
+              disk:
+                bus: virtio
+
+          interfaces:
+            - name: default
+              bridge: {}
+              macAddress: "52:54:00:30:00:02"  # Static MAC for consistent IP
+
+        # Resource overcommit settings
+        resources:
+          requests:
+            memory: 16Gi
+            cpu: "4"
+          limits:
+            memory: 16Gi
+            cpu: "4"
+
+        # Machine type
+        machine:
+          type: q35
+
+        # Features
+        features:
+          acpi:
+            enabled: true
+          smm:
+            enabled: true
+
+        # Firmware
+        firmware:
+          bootloader:
+            efi:
+              secureBoot: false
+
+      # Network configuration
+      networks:
+        - name: default
+          multus:
+            networkName: default/platform  # References ClusterNetwork 'platform'
+
+      # Volumes
+      volumes:
+        - name: rootdisk
+          persistentVolumeClaim:
+            claimName: platform-cp-2-rootdisk
+
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            networkData: |
+              version: 2
+              ethernets:
+                eth0:
+                  addresses:
+                    - 10.10.30.12/24
+                  gateway4: 10.10.30.1
+                  nameservers:
+                    addresses:
+                      - 10.10.10.1
+                      - 1.1.1.1
+
+            # Talos machine configuration URL
+            # Served by Tinkerbell config-server or NGINX
+            userData: |
+              #cloud-config
+              talos:
+                config_url: http://10.10.10.5:8080/talos/platform-cp-2.yaml
+
+---
+# PVC for root disk (cloned from Talos image)
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: platform-cp-2-rootdisk
+  namespace: default
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"  # Create before VM
+    harvesterhci.io/imageId: default/talos-1.9.0  # Clone from image
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 50Gi
+  storageClassName: longhorn
+  volumeMode: Block
+```
+
+**Key Configuration Details:**
+
+| Component | Value | Purpose |
+|:---|:---|:---|
+| `running: true` | VM starts automatically | Ensures VM boots after creation |
+| `cores: 4, memory: 16Gi` | Resource allocation | Control plane sizing |
+| `macAddress: 52:54:00:30:00:02` | Static MAC | Consistent DHCP/static IP assignment |
+| `networkName: default/platform` | VLAN 30 network | Isolates platform traffic |
+| `imageId: default/talos-1.9.0` | Clone Talos image | Fast provisioning from template |
+| `config_url` | Talos machine config | PXE-style config fetch for cloud-init |
+
+### Platform CP-3 VM Definition
+
+Similar to CP-2, with unique identifiers:
+
+```yaml
+# File: clusters/harvester/vms/platform/cp-3.yaml
+# Purpose: Platform cluster control plane node 3 (Harvester VM)
+
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: platform-cp-3
+  namespace: default
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+    harvesterhci.io/description: "Platform cluster control plane node 3"
+  labels:
+    harvesterhci.io/cluster: platform
+    harvesterhci.io/node-role: control-plane
+    harvesterhci.io/os: talos
+spec:
+  running: true
+  template:
+    metadata:
+      labels:
+        kubevirt.io/vm: platform-cp-3
+        harvesterhci.io/cluster: platform
+        harvesterhci.io/node-role: control-plane
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: harvesterhci.io/cluster
+                      operator: In
+                      values:
+                        - platform
+                topologyKey: kubernetes.io/hostname
+      domain:
+        cpu:
+          cores: 4
+          sockets: 1
+          threads: 1
+        memory:
+          guest: 16Gi
+        devices:
+          disks:
+            - name: rootdisk
+              bootOrder: 1
+              disk:
+                bus: virtio
+            - name: cloudinitdisk
+              disk:
+                bus: virtio
+          interfaces:
+            - name: default
+              bridge: {}
+              macAddress: "52:54:00:30:00:03"  # Unique MAC
+        resources:
+          requests:
+            memory: 16Gi
+            cpu: "4"
+          limits:
+            memory: 16Gi
+            cpu: "4"
+        machine:
+          type: q35
+        features:
+          acpi:
+            enabled: true
+          smm:
+            enabled: true
+        firmware:
+          bootloader:
+            efi:
+              secureBoot: false
+      networks:
+        - name: default
+          multus:
+            networkName: default/platform
+      volumes:
+        - name: rootdisk
+          persistentVolumeClaim:
+            claimName: platform-cp-3-rootdisk
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            networkData: |
+              version: 2
+              ethernets:
+                eth0:
+                  addresses:
+                    - 10.10.30.13/24  # Unique IP
+                  gateway4: 10.10.30.1
+                  nameservers:
+                    addresses:
+                      - 10.10.10.1
+                      - 1.1.1.1
+            userData: |
+              #cloud-config
+              talos:
+                config_url: http://10.10.10.5:8080/talos/platform-cp-3.yaml  # Unique config
+
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: platform-cp-3-rootdisk
+  namespace: default
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+    harvesterhci.io/imageId: default/talos-1.9.0
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 50Gi
+  storageClassName: longhorn
+  volumeMode: Block
+```
+
+### Standalone VM Considerations
+
+Standalone VMs (e.g., Windows gaming VM, TrueNAS) follow the same structure but with different requirements:
+
+**Example: Windows Gaming VM (Conceptual)**
+
+```yaml
+# File: clusters/harvester/vms/standalone/windows-gaming.yaml
+# Note: This is a conceptual example, not deployed in initial lab
+
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: windows-gaming
+  namespace: default
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+    harvesterhci.io/description: "Windows gaming workstation"
+spec:
+  running: false  # Manual start/stop for gaming sessions
+  template:
+    spec:
+      domain:
+        cpu:
+          cores: 8
+          sockets: 1
+          threads: 2
+        memory:
+          guest: 32Gi
+        devices:
+          disks:
+            - name: rootdisk
+              bootOrder: 1
+              disk:
+                bus: sata
+            - name: datadisk
+              disk:
+                bus: scsi
+          interfaces:
+            - name: default
+              bridge: {}
+          # GPU passthrough (if configured)
+          hostDevices:
+            - name: gpu
+              deviceName: nvidia.com/GPU_0f17_2267
+        resources:
+          requests:
+            memory: 32Gi
+            cpu: "16"
+        machine:
+          type: pc-q35-5.2
+        features:
+          acpi:
+            enabled: true
+          hyperv:
+            relaxed:
+              enabled: true
+            vapic:
+              enabled: true
+            spinlocks:
+              enabled: true
+              spinlocks: 8191
+        firmware:
+          bootloader:
+            efi:
+              secureBoot: false
+      networks:
+        - name: default
+          multus:
+            networkName: default/mgmt
+      volumes:
+        - name: rootdisk
+          persistentVolumeClaim:
+            claimName: windows-gaming-rootdisk
+        - name: datadisk
+          persistentVolumeClaim:
+            claimName: windows-gaming-datadisk
+```
+
+**Standalone VM Characteristics:**
+- Larger resource allocations (gaming, media processing)
+- GPU/hardware passthrough capabilities
+- Different OS images (Windows, TrueNAS, etc.)
+- Manual start/stop policies
+- VLAN 10 (mgmt) network for LAN access
+
+---
+
+## Storage Configuration
+
+Harvester uses Longhorn for VM disk storage. Storage classes define performance characteristics and replication policies.
+
+### Longhorn Storage Classes
+
+#### Default Storage Class
+
+```yaml
+# Created by Harvester automatically
+# High availability with 3-replica replication
+
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: longhorn
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+provisioner: driver.longhorn.io
+allowVolumeExpansion: true
+reclaimPolicy: Delete
+volumeBindingMode: Immediate
+parameters:
+  numberOfReplicas: "3"
+  staleReplicaTimeout: "2880"
+  fromBackup: ""
+  fsType: "ext4"
+  dataLocality: "disabled"
+  replicaAutoBalance: "best-effort"
+```
+
+#### Fast Storage Class (SSD-only)
+
+```yaml
+# File: clusters/harvester/config/storage/longhorn-fast.yaml
+# Purpose: High-performance storage for database VMs
+
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: longhorn-fast
+  annotations:
+    argocd.argoproj.io/sync-wave: "-3"
+provisioner: driver.longhorn.io
+allowVolumeExpansion: true
+reclaimPolicy: Delete
+volumeBindingMode: WaitForFirstConsumer
+parameters:
+  numberOfReplicas: "2"
+  staleReplicaTimeout: "2880"
+  dataLocality: "best-effort"
+  replicaAutoBalance: "best-effort"
+  diskSelector: "ssd"  # Only use nodes with SSD tag
+  nodeSelector: ""
+```
+
+#### Single-Replica Storage Class (Ephemeral)
+
+```yaml
+# File: clusters/harvester/config/storage/longhorn-single.yaml
+# Purpose: Non-critical data, faster provisioning
+
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: longhorn-single
+  annotations:
+    argocd.argoproj.io/sync-wave: "-3"
+provisioner: driver.longhorn.io
+allowVolumeExpansion: true
+reclaimPolicy: Delete
+volumeBindingMode: Immediate
+parameters:
+  numberOfReplicas: "1"
+  staleReplicaTimeout: "2880"
+  dataLocality: "disabled"
+  replicaAutoBalance: "disabled"
+```
+
+### VM Disk Provisioning
+
+When a VirtualMachine CRD references a PVC, Longhorn provisions the disk:
+
+**Process Flow:**
+```
+1. VirtualMachine CRD created
+   ↓
+2. References PVC (platform-cp-2-rootdisk)
+   ↓
+3. PVC has annotation harvesterhci.io/imageId: default/talos-1.9.0
+   ↓
+4. Harvester clones VirtualMachineImage PVC to new PVC
+   ↓
+5. Longhorn provisions replicated volume
+   ↓
+6. PVC bound, VM can start
+```
+
+**Storage Performance Considerations:**
+
+| Use Case | Storage Class | Replicas | Rationale |
+|:---|:---|:---:|:---|
+| Control plane VMs | `longhorn` (default) | 3 | High availability required |
+| Worker node VMs | `longhorn` (default) | 3 | Data durability |
+| Database VMs | `longhorn-fast` | 2 | Performance + availability |
+| Temp/cache volumes | `longhorn-single` | 1 | Speed, non-critical data |
+
+---
+
+## Integration with CAPI
+
+Harvester integrates with Cluster API (CAPI) to provision tenant cluster VMs dynamically. This section clarifies the distinction between Harvester-managed and CAPI-managed VMs.
+
+### Harvester Provider Overview
+
+The CAPI Harvester provider allows CAPI to create and manage VirtualMachine CRDs in the Harvester cluster.
+
+**Architecture:**
+```
+Platform Cluster (CAPI)                 Harvester Cluster
+┌────────────────────────┐             ┌────────────────────────┐
+│ TenantCluster XR       │             │                        │
+│   ↓                    │             │                        │
+│ CAPI Cluster CRD       │             │                        │
+│   ↓                    │             │                        │
+│ CAPI Machine CRDs      │─────────────▶│ VirtualMachine CRDs   │
+│   ↓                    │   Harvester  │   ↓                    │
+│ CAPI Talos Bootstrap   │   Provider   │ KubeVirt creates VMs  │
+└────────────────────────┘             └────────────────────────┘
+```
+
+### How CAPI Uses Harvester Provider
+
+When a TenantCluster XR is created (e.g., `clusters/media/cluster.yaml`):
+
+1. **Crossplane processes XR** and creates CAPI Cluster resource
+2. **CAPI Harvester provider** reads CAPI Machine specs
+3. **Provider creates VirtualMachine CRDs** in Harvester cluster
+4. **KubeVirt reconciles VMs** on Harvester nodes
+5. **CAPI Talos provider** generates machine configs
+6. **VMs boot** and join the tenant cluster
+
+**Example CAPI-Generated VirtualMachine (Conceptual):**
+
+```yaml
+# Created by CAPI Harvester provider, NOT by Argo CD
+# Lives in Harvester cluster
+
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: media-control-plane-0
+  namespace: default
+  labels:
+    cluster.x-k8s.io/cluster-name: media
+    cluster.x-k8s.io/role: control-plane
+    capi.harvesterhci.io/managed: "true"
+spec:
+  running: true
+  template:
+    spec:
+      domain:
+        cpu:
+          cores: 4
+        memory:
+          guest: 8Gi
+        devices:
+          disks:
+            - name: rootdisk
+              disk:
+                bus: virtio
+          interfaces:
+            - name: default
+              bridge: {}
+      networks:
+        - name: default
+          multus:
+            networkName: default/cluster  # VLAN 40
+      volumes:
+        - name: rootdisk
+          persistentVolumeClaim:
+            claimName: media-control-plane-0-rootdisk
+```
+
+**Differences from Harvester-Managed VMs:**
+
+| Aspect | Harvester-Managed (Platform CP-2/CP-3) | CAPI-Managed (Tenant Clusters) |
+|:---|:---|:---|
+| **Defined in** | Git repo (`clusters/harvester/vms/`) | Generated dynamically by CAPI |
+| **Lifecycle** | Managed by Argo CD | Managed by CAPI controllers |
+| **Network** | VLAN 30 (platform) | VLAN 40 (cluster) |
+| **Purpose** | Bootstrap platform HA | Tenant workload clusters |
+| **Configuration** | cloud-init with Talos config URL | CAPI Talos provider auto-config |
+| **Deletion** | Manual (or Argo CD prune) | Automatic when TenantCluster XR deleted |
+
+### Distinction: Raw VMs vs CAPI-Managed VMs
+
+```
+clusters/harvester/vms/
+├── platform/              ← Harvester-managed (Argo CD)
+│   ├── cp-2.yaml          ← Bootstrap only, manual VirtualMachine CRD
+│   └── cp-3.yaml          ← Bootstrap only, manual VirtualMachine CRD
+└── standalone/            ← Harvester-managed (Argo CD)
+    └── (future VMs)       ← Permanent, manual VirtualMachine CRDs
+
+(Not in repo)
+Tenant cluster VMs         ← CAPI-managed (dynamic)
+  - Created by CAPI Harvester provider
+  - Defined by TenantCluster XR composition
+  - Lifecycle tied to CAPI Cluster resource
+```
+
+**Why Platform VMs are in Git:**
+- Platform cluster exists BEFORE CAPI is available
+- Cannot use TenantCluster XR to provision platform itself (chicken-and-egg)
+- Explicit VirtualMachine CRDs enable manual bootstrap
+- After bootstrap, these VMs could theoretically be migrated to CAPI management
+
+**Why Tenant VMs are NOT in Git:**
+- Fully declarative via TenantCluster XR
+- CAPI handles VM lifecycle automatically
+- Cluster scaling (add/remove nodes) handled by CAPI
+- No manual VM definition required
+
+---
+
+## Summary Tables
+
+### Network Summary
+
+| Network | VLAN | Subnet | MTU | Used By |
+|:---|:---:|:---|:---:|:---|
+| `mgmt` | 10 | 10.10.10.0/24 | 1500 | Harvester, infrastructure |
+| `platform` | 30 | 10.10.30.0/24 | 1500 | Platform CP-2, CP-3 |
+| `cluster` | 40 | 10.10.40.0/24 | 9000 | Tenant cluster VMs |
+| `storage` | 60 | 10.10.60.0/24 | 9000 | Longhorn replication |
+
+### Image Summary
+
+| Image | Version | Size | Used By |
+|:---|:---|:---|:---|
+| `talos-1.9.0` | 1.9.0 | ~1GB | Platform VMs, tenant VMs |
+| `ubuntu-22.04` | 22.04 LTS | ~2GB | Standalone VMs |
+| `windows-server-2022` | 2022 | ~20GB | Standalone VMs (if needed) |
+
+### VM Summary
+
+| VM Name | CPU | Memory | Disk | Network | Purpose |
+|:---|:---:|:---:|:---:|:---|:---|
+| `platform-cp-2` | 4 | 16Gi | 50Gi | VLAN 30 | Platform HA node |
+| `platform-cp-3` | 4 | 16Gi | 50Gi | VLAN 30 | Platform HA node |
+| (CAPI tenant VMs) | Variable | Variable | Variable | VLAN 40 | Dynamic tenant clusters |
+
+### Storage Class Summary
+
+| Storage Class | Replicas | Use Case | Performance |
+|:---|:---:|:---|:---|
+| `longhorn` (default) | 3 | HA workloads | Balanced |
+| `longhorn-fast` | 2 | Databases | High IOPS |
+| `longhorn-single` | 1 | Ephemeral data | Fast provisioning |
+
+---
+
+## References
+
+- See main architecture documentation for high-level concepts
+- See Appendix C for Argo CD ApplicationSet configuration
+- Harvester documentation: https://docs.harvesterhci.io/
+- KubeVirt documentation: https://kubevirt.io/
+- Longhorn documentation: https://longhorn.io/
+- CAPI Harvester provider: https://github.com/harvester/cluster-api-provider-harvester

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -42,7 +42,9 @@ This documentation describes a fully automated, GitOps-focused, multi-cluster Ta
 
 | Concept | Description |
 |:---|:---|
+| [Argo CD](08_concepts/argocd.md) | Hub-and-spoke GitOps, ApplicationSets |
 | [Control Plane](08_concepts/control_plane.md) | Crossplane unified API layer |
+| [Harvester](08_concepts/harvester.md) | HCI integration as managed cluster |
 | [Load Balancing](08_concepts/load_balancing.md) | BGP-based service exposure |
 | [Networking](08_concepts/networking.md) | VLAN architecture, Split Plane design |
 | [Observability](08_concepts/observability.md) | Prometheus, Grafana, alerting |
@@ -57,6 +59,18 @@ This documentation describes a fully automated, GitOps-focused, multi-cluster Ta
 | [ADR 001](09_design_decisions/001_use_bgp_loadbalancing.md) | BGP over Layer 2 for load balancing |
 | [ADR 002](09_design_decisions/002_networking_topology.md) | LACP bonding over physical segregation |
 | [ADR 003](09_design_decisions/003_vyos_gitops.md) | Ansible + GitHub Actions + Tailscale for VyOS management |
+| [ADR 004](09_design_decisions/004_argocd_hub_spoke.md) | Hub-and-spoke Argo CD over agent model |
+| [ADR 005](09_design_decisions/005_seed_bootstrap_strategy.md) | Minimal seed with raw manifests for bootstrap |
+| [ADR 006](09_design_decisions/006_harvester_managed_cluster.md) | Harvester as Argo CD managed cluster |
+
+### Appendices
+
+| Appendix | Description |
+|:---|:---|
+| [A. Repository Structure](appendices/A_repository_structure.md) | Monorepo layout and directory conventions |
+| [B. Bootstrap Procedure](appendices/B_bootstrap_procedure.md) | 4-phase, 18-step genesis bootstrap runbook |
+| [C. Argo CD Configuration](appendices/C_argocd_configuration.md) | ApplicationSets, cluster secrets, health checks |
+| [D. Harvester Configuration](appendices/D_harvester_configuration.md) | Network, storage, and VM CRD examples |
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds VyOS router provisioning as part of the genesis bootstrap sequence
- Ensures lab networking infrastructure is fully reproducible from scratch
- Expands bootstrap documentation with comprehensive appendices

## Changes

### VyOS Bootstrap Integration
- Add Packer build location for VyOS image (`infrastructure/network/vyos/packer/`)
- Add VyOS hardware/workflow definitions to `bootstrap/seed/`
- Update bootstrap procedure from 18 to 20 steps:
  - **Step 1**: Build VyOS Image (Packer)
  - **Step 7**: VyOS Boots via PXE (establishes lab networking)
- Update all sequence diagrams to include VyOS
- Update deployment view: VyOS now deployed via Tinkerbell PXE

### New Documentation
- `appendices/A_repository_structure.md` - Complete directory tree reference
- `appendices/B_bootstrap_procedure.md` - 4-phase, 20-step bootstrap runbook
- `appendices/C_argocd_configuration.md` - ApplicationSets and cluster secrets
- `appendices/D_harvester_configuration.md` - Network and VM CRD examples
- `08_concepts/argocd.md` - Hub-and-spoke GitOps pattern
- `08_concepts/harvester.md` - HCI as managed cluster
- `09_design_decisions/004_argocd_hub_spoke.md` - ADR for Argo CD topology
- `09_design_decisions/005_seed_bootstrap_strategy.md` - ADR for minimal seed
- `09_design_decisions/006_harvester_managed_cluster.md` - ADR for Harvester management

## Test plan

- [ ] Review all updated sequence diagrams render correctly
- [ ] Verify step numbering is consistent across all documents
- [ ] Confirm cross-references between documents are valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)