### PR TITLE
feat(labctl): add caching for image downloads and hooks

### DIFF
--- a/.github/workflows/images-sync.yml
+++ b/.github/workflows/images-sync.yml
@@ -89,11 +89,20 @@ jobs:
         run: |
           pip install -r infrastructure/network/vyos/tests/requirements.txt
 
+      # Cache for downloaded ISOs and hook artifacts (rootfs.tar)
+      - name: Setup labctl cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/labctl
+          key: labctl-images-${{ hashFiles('images/images.yaml') }}
+          restore-keys: |
+            labctl-images-
+
       # PR: run full sync without upload (tests hooks, no credentials needed)
       - name: Sync Images (PR - no upload)
         if: github.event_name == 'pull_request'
         run: |
-          ./labctl images sync --no-upload
+          ./labctl images sync --no-upload --cache-dir ~/.cache/labctl
 
       # Push/dispatch: full sync with credentials
       - name: Install SOPS
@@ -120,6 +129,7 @@ jobs:
           ./labctl images sync \
             --credentials images/e2.sops.yaml \
             --sops-age-key-file /tmp/age-key.txt \
+            --cache-dir ~/.cache/labctl \
             $FLAGS
 
       - name: Create PR if files changed

--- a/tools/labctl/cmd/images/sync_test.go
+++ b/tools/labctl/cmd/images/sync_test.go
@@ -225,7 +225,7 @@ func TestSyncImage(t *testing.T) {
 			},
 		}
 
-		changed, err := syncImage(context.Background(), client, nil, img, false, false, false)
+		changed, err := syncImage(context.Background(), client, nil, nil, img, false, false, false)
 
 		require.NoError(t, err)
 		assert.False(t, changed)
@@ -244,7 +244,7 @@ func TestSyncImage(t *testing.T) {
 			},
 		}
 
-		changed, err := syncImage(context.Background(), client, nil, img, true, false, false)
+		changed, err := syncImage(context.Background(), client, nil, nil, img, true, false, false)
 
 		require.NoError(t, err)
 		assert.False(t, changed)
@@ -273,7 +273,7 @@ func TestSyncImage(t *testing.T) {
 
 		// With force=true and dryRun=true, it should show what would be done
 		// without checking checksum
-		_, err := syncImage(context.Background(), client, nil, img, true, true, false)
+		_, err := syncImage(context.Background(), client, nil, nil, img, true, true, false)
 
 		require.NoError(t, err)
 		assert.False(t, checksumChecked) // Should not check checksum with force
@@ -295,7 +295,7 @@ func TestSyncImage(t *testing.T) {
 			},
 		}
 
-		_, err := syncImage(context.Background(), client, nil, img, false, false, false)
+		_, err := syncImage(context.Background(), client, nil, nil, img, false, false, false)
 
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "check existing image")
@@ -321,7 +321,7 @@ func TestSyncImage(t *testing.T) {
 
 		// With noUpload=true, should skip checksum check (client is nil for noUpload)
 		// and also skip upload - this test verifies the skip behavior
-		changed, err := syncImage(context.Background(), client, nil, img, true, false, false)
+		changed, err := syncImage(context.Background(), client, nil, nil, img, true, false, false)
 
 		require.NoError(t, err)
 		assert.False(t, changed)
@@ -379,7 +379,7 @@ func TestSyncImageWithHTTP(t *testing.T) {
 			},
 		}
 
-		changed, err := syncImageWithHTTP(context.Background(), client, server.Client(), nil, img, false, false, false)
+		changed, err := syncImageWithHTTP(context.Background(), client, server.Client(), nil, nil, img, false, false, false)
 
 		require.NoError(t, err)
 		assert.False(t, changed) // No updateFile, so no file changes
@@ -449,7 +449,7 @@ func TestSyncImageWithHTTP(t *testing.T) {
 			},
 		}
 
-		changed, err := syncImageWithHTTP(context.Background(), client, server.Client(), nil, img, false, false, false)
+		changed, err := syncImageWithHTTP(context.Background(), client, server.Client(), nil, nil, img, false, false, false)
 
 		require.NoError(t, err)
 		assert.False(t, changed)
@@ -484,7 +484,7 @@ func TestSyncImageWithHTTP(t *testing.T) {
 			},
 		}
 
-		_, err := syncImageWithHTTP(context.Background(), client, server.Client(), nil, img, false, false, false)
+		_, err := syncImageWithHTTP(context.Background(), client, server.Client(), nil, nil, img, false, false, false)
 
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "download")
@@ -514,7 +514,7 @@ func TestSyncImageWithHTTP(t *testing.T) {
 			},
 		}
 
-		_, err := syncImageWithHTTP(context.Background(), client, server.Client(), nil, img, false, false, false)
+		_, err := syncImageWithHTTP(context.Background(), client, server.Client(), nil, nil, img, false, false, false)
 
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "source checksum verification")
@@ -548,7 +548,7 @@ func TestSyncImageWithHTTP(t *testing.T) {
 			},
 		}
 
-		_, err := syncImageWithHTTP(context.Background(), client, server.Client(), nil, img, false, false, false)
+		_, err := syncImageWithHTTP(context.Background(), client, server.Client(), nil, nil, img, false, false, false)
 
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "upload")
@@ -585,7 +585,7 @@ func TestSyncImageWithHTTP(t *testing.T) {
 			},
 		}
 
-		_, err := syncImageWithHTTP(context.Background(), client, server.Client(), nil, img, false, false, false)
+		_, err := syncImageWithHTTP(context.Background(), client, server.Client(), nil, nil, img, false, false, false)
 
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "write metadata")
@@ -628,7 +628,7 @@ func TestSyncImageWithHTTP(t *testing.T) {
 			},
 		}
 
-		_, err = syncImageWithHTTP(context.Background(), client, server.Client(), nil, img, false, false, false)
+		_, err = syncImageWithHTTP(context.Background(), client, server.Client(), nil, nil, img, false, false, false)
 
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "decompressed checksum verification")
@@ -676,7 +676,7 @@ func TestSyncImageWithHTTP(t *testing.T) {
 		}
 
 		// noUpload=true should download, verify, but skip upload
-		changed, err := syncImageWithHTTP(context.Background(), client, server.Client(), nil, img, false, false, true)
+		changed, err := syncImageWithHTTP(context.Background(), client, server.Client(), nil, nil, img, false, false, true)
 
 		require.NoError(t, err)
 		assert.False(t, changed)

--- a/tools/labctl/internal/cache/cache.go
+++ b/tools/labctl/internal/cache/cache.go
@@ -1,0 +1,135 @@
+// Package cache provides local file caching for the image pipeline.
+package cache
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Manager handles local file caching by checksum.
+// Files are stored in a directory structure under the base directory.
+type Manager struct {
+	baseDir string
+}
+
+// NewManager creates a new cache manager with the given base directory.
+// Returns an error if the directory cannot be created.
+func NewManager(baseDir string) (*Manager, error) {
+	if baseDir == "" {
+		return nil, fmt.Errorf("cache directory cannot be empty")
+	}
+
+	// Create base directory and subdirectories
+	dirs := []string{
+		filepath.Join(baseDir, "downloads"),
+		filepath.Join(baseDir, "hooks"),
+	}
+	for _, dir := range dirs {
+		if err := os.MkdirAll(dir, 0o750); err != nil {
+			return nil, fmt.Errorf("create cache directory %s: %w", dir, err)
+		}
+	}
+
+	return &Manager{baseDir: baseDir}, nil
+}
+
+// BaseDir returns the base cache directory.
+func (m *Manager) BaseDir() string {
+	return m.baseDir
+}
+
+// Get returns the path to a cached file for the given checksum.
+// Returns the path and true if the file exists, empty string and false otherwise.
+func (m *Manager) Get(checksum string) (string, bool) {
+	key := checksumKey(checksum)
+	cachePath := filepath.Join(m.baseDir, "downloads", key)
+
+	if _, err := os.Stat(cachePath); err != nil {
+		return "", false
+	}
+
+	return cachePath, true
+}
+
+// Put stores content from the reader to the cache under the given checksum.
+// Returns the path to the cached file.
+func (m *Manager) Put(checksum string, src io.Reader) (string, error) {
+	key := checksumKey(checksum)
+	cachePath := filepath.Join(m.baseDir, "downloads", key)
+
+	// Write to temp file first, then rename for atomicity
+	tempPath := cachePath + ".tmp"
+	f, err := os.Create(tempPath) //nolint:gosec // G304: Path is constructed from trusted cache directory
+	if err != nil {
+		return "", fmt.Errorf("create cache file: %w", err)
+	}
+
+	_, err = io.Copy(f, src)
+	if closeErr := f.Close(); closeErr != nil && err == nil {
+		err = closeErr
+	}
+	if err != nil {
+		_ = os.Remove(tempPath)
+		return "", fmt.Errorf("write cache file: %w", err)
+	}
+
+	if err := os.Rename(tempPath, cachePath); err != nil {
+		_ = os.Remove(tempPath)
+		return "", fmt.Errorf("rename cache file: %w", err)
+	}
+
+	return cachePath, nil
+}
+
+// Remove deletes a cached file for the given checksum.
+func (m *Manager) Remove(checksum string) error {
+	key := checksumKey(checksum)
+	cachePath := filepath.Join(m.baseDir, "downloads", key)
+	return os.Remove(cachePath)
+}
+
+// HookDir returns the cache directory for a specific hook.
+// Creates the directory if it doesn't exist.
+func (m *Manager) HookDir(hookName string) (string, error) {
+	// Sanitize hook name for filesystem safety
+	safeName := sanitizeName(hookName)
+	hookDir := filepath.Join(m.baseDir, "hooks", safeName)
+
+	if err := os.MkdirAll(hookDir, 0o750); err != nil {
+		return "", fmt.Errorf("create hook cache directory: %w", err)
+	}
+
+	return hookDir, nil
+}
+
+// checksumKey converts a checksum string to a safe cache key.
+// Uses the first 12 characters of sha256 hash for compact, unique names.
+func checksumKey(checksum string) string {
+	// Remove algorithm prefix if present (e.g., "sha256:abc123...")
+	if idx := strings.Index(checksum, ":"); idx != -1 {
+		checksum = checksum[idx+1:]
+	}
+
+	// Hash the checksum to get a consistent, safe filename
+	h := sha256.Sum256([]byte(checksum))
+	return hex.EncodeToString(h[:])[:12]
+}
+
+// sanitizeName makes a string safe for use as a filename.
+func sanitizeName(name string) string {
+	// Replace any non-alphanumeric characters with underscore
+	var result strings.Builder
+	for _, r := range name {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '-' || r == '_' {
+			result.WriteRune(r)
+		} else {
+			result.WriteRune('_')
+		}
+	}
+	return result.String()
+}

--- a/tools/labctl/internal/cache/cache_test.go
+++ b/tools/labctl/internal/cache/cache_test.go
@@ -1,0 +1,164 @@
+package cache
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestNewManager(t *testing.T) {
+	t.Run("creates directories", func(t *testing.T) {
+		dir := t.TempDir()
+		baseDir := filepath.Join(dir, "cache")
+
+		m, err := NewManager(baseDir)
+		if err != nil {
+			t.Fatalf("NewManager() error = %v", err)
+		}
+
+		// Verify directories were created
+		for _, subdir := range []string{"downloads", "hooks"} {
+			path := filepath.Join(baseDir, subdir)
+			if _, err := os.Stat(path); os.IsNotExist(err) {
+				t.Errorf("directory %s was not created", subdir)
+			}
+		}
+
+		if m.BaseDir() != baseDir {
+			t.Errorf("BaseDir() = %q, want %q", m.BaseDir(), baseDir)
+		}
+	})
+
+	t.Run("returns error for empty path", func(t *testing.T) {
+		_, err := NewManager("")
+		if err == nil {
+			t.Error("NewManager(\"\") should return error")
+		}
+	})
+}
+
+func TestManager_GetPut(t *testing.T) {
+	dir := t.TempDir()
+	m, err := NewManager(filepath.Join(dir, "cache"))
+	if err != nil {
+		t.Fatalf("NewManager() error = %v", err)
+	}
+
+	checksum := "sha256:abc123def456"
+	content := "test content"
+
+	t.Run("Get returns false for missing file", func(t *testing.T) {
+		_, ok := m.Get(checksum)
+		if ok {
+			t.Error("Get() should return false for missing file")
+		}
+	})
+
+	t.Run("Put stores and Get retrieves", func(t *testing.T) {
+		path, err := m.Put(checksum, strings.NewReader(content))
+		if err != nil {
+			t.Fatalf("Put() error = %v", err)
+		}
+
+		// Verify file was created
+		data, err := os.ReadFile(path) //nolint:gosec // G304: Test file path
+		if err != nil {
+			t.Fatalf("ReadFile(%s) error = %v", path, err)
+		}
+		if string(data) != content {
+			t.Errorf("file content = %q, want %q", string(data), content)
+		}
+
+		// Verify Get returns the path
+		gotPath, ok := m.Get(checksum)
+		if !ok {
+			t.Error("Get() should return true after Put()")
+		}
+		if gotPath != path {
+			t.Errorf("Get() path = %q, want %q", gotPath, path)
+		}
+	})
+
+	t.Run("Remove deletes cached file", func(t *testing.T) {
+		err := m.Remove(checksum)
+		if err != nil {
+			t.Fatalf("Remove() error = %v", err)
+		}
+
+		_, ok := m.Get(checksum)
+		if ok {
+			t.Error("Get() should return false after Remove()")
+		}
+	})
+}
+
+func TestManager_HookDir(t *testing.T) {
+	dir := t.TempDir()
+	m, err := NewManager(filepath.Join(dir, "cache"))
+	if err != nil {
+		t.Fatalf("NewManager() error = %v", err)
+	}
+
+	t.Run("creates hook directory", func(t *testing.T) {
+		hookDir, err := m.HookDir("vyos-integration-test")
+		if err != nil {
+			t.Fatalf("HookDir() error = %v", err)
+		}
+
+		if _, err := os.Stat(hookDir); os.IsNotExist(err) {
+			t.Error("HookDir() did not create directory")
+		}
+
+		// Verify it's under the hooks subdirectory
+		if !strings.Contains(hookDir, "hooks") {
+			t.Errorf("HookDir() = %q, expected to contain 'hooks'", hookDir)
+		}
+	})
+
+	t.Run("sanitizes hook name", func(t *testing.T) {
+		hookDir, err := m.HookDir("hook/with:special*chars")
+		if err != nil {
+			t.Fatalf("HookDir() error = %v", err)
+		}
+
+		// Path should not contain special characters
+		base := filepath.Base(hookDir)
+		for _, char := range []string{"/", ":", "*"} {
+			if strings.Contains(base, char) {
+				t.Errorf("HookDir base %q contains special char %q", base, char)
+			}
+		}
+	})
+}
+
+func TestChecksumKey(t *testing.T) {
+	tests := []struct {
+		name     string
+		checksum string
+	}{
+		{"with prefix", "sha256:abc123def456"},
+		{"without prefix", "abc123def456"},
+		{"sha512 prefix", "sha512:abc123def456"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			key := checksumKey(tt.checksum)
+
+			// Key should be exactly 12 hex characters
+			if len(key) != 12 {
+				t.Errorf("checksumKey() length = %d, want 12", len(key))
+			}
+
+			// Key should only contain hex characters
+			for _, c := range key {
+				isDigit := c >= '0' && c <= '9'
+				isHexLetter := c >= 'a' && c <= 'f'
+				if !isDigit && !isHexLetter {
+					t.Errorf("checksumKey() contains non-hex char: %c", c)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Add `--cache-dir` flag to `labctl images sync` for local download caching
- Create `internal/cache` package for managing cached files by checksum
- Pass `LABCTL_HOOK_CACHE` environment variable to hooks for artifact caching
- Update `iso-to-container.sh` to cache `rootfs.tar` by ISO hash
- Add `actions/cache` step to `images-sync.yml` workflow

## Cache Structure

```
~/.cache/labctl/
├── downloads/     # Cached ISOs by checksum hash (12-char key)
└── hooks/
    └── vyos-integration-test/
        └── rootfs-{iso-hash}.tar
```

## Expected CI Time Savings

| Phase | Without Cache | With Cache |
|-------|---------------|------------|
| ISO Download (~400MB) | ~60s | ~0s |
| sqfs2tar (~2GB rootfs) | ~90s | ~5s |
| **Total per image** | ~3 min | ~45s |

## Test plan

- [ ] CI workflow runs successfully on this PR
- [ ] First run downloads and caches the ISO
- [ ] Second run uses cached ISO (look for "Using cached:" in logs)
- [ ] Hook caching works (look for "Using cached rootfs.tar:" in iso-to-container.sh output)

🤖 Generated with [Claude Code](https://claude.com/claude-code)