### PR TITLE
ci: add talhelper for transform hooks in images-sync workflow

### DIFF
--- a/.github/workflows/images-sync.yml
+++ b/.github/workflows/images-sync.yml
@@ -107,12 +107,22 @@ jobs:
           ./labctl images sync --no-upload --skip-transform-hooks --cache-dir ~/.cache/labctl
 
       # Push/dispatch: full sync with credentials
+      # Install tools needed for transform hooks (talhelper, sops)
       - name: Install SOPS
         if: github.event_name != 'pull_request'
         run: |
           curl -LO https://github.com/getsops/sops/releases/download/v3.9.4/sops-v3.9.4.linux.amd64
           chmod +x sops-v3.9.4.linux.amd64
           sudo mv sops-v3.9.4.linux.amd64 /usr/local/bin/sops
+
+      - name: Install talhelper
+        if: github.event_name != 'pull_request'
+        run: |
+          curl -LO https://github.com/budimanjojo/talhelper/releases/download/v3.0.13/talhelper_linux_amd64.tar.gz
+          tar -xzf talhelper_linux_amd64.tar.gz
+          chmod +x talhelper
+          sudo mv talhelper /usr/local/bin/talhelper
+          talhelper --version
 
       - name: Write SOPS age key
         if: github.event_name != 'pull_request'


### PR DESCRIPTION
## Summary
- Adds talhelper installation step to the images-sync CI workflow
- Required for transform hooks that generate Talos machine configurations
- Fixes master branch sync failure after merging HOM-27

## Context
The talos-um760 image uses a transform hook that runs `talos-embed-config.sh`, which requires:
- `talhelper` - generates machine configurations from talconfig.yaml
- `sops` - decrypts secrets in talconfig (already installed)

Without talhelper, the transform hook fails with "Missing dependencies: talhelper".

## Test plan
- [ ] CI workflow runs successfully on this PR (PR mode uses `--skip-transform-hooks`)
- [ ] After merge, master branch sync should succeed with transform hooks enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)