### PR TITLE
ci: export SOPS_AGE_KEY_FILE for transform hooks

### DIFF
--- a/.github/workflows/images-sync.yml
+++ b/.github/workflows/images-sync.yml
@@ -133,6 +133,8 @@ jobs:
       - name: Sync Images
         if: github.event_name != 'pull_request'
         id: sync
+        env:
+          SOPS_AGE_KEY_FILE: /tmp/age-key.txt
         run: |
           FLAGS=""
           if [ "${{ inputs.force }}" == "true" ]; then FLAGS="$FLAGS --force"; fi


### PR DESCRIPTION
## Summary
- Exports `SOPS_AGE_KEY_FILE` environment variable in the Sync Images step
- Required for transform hooks that use talhelper to decrypt secrets via SOPS

## Context
The talos-embed-config.sh transform hook runs `talhelper genconfig`, which needs SOPS to decrypt secrets in `talconfig.yaml`. The age key file is written to `/tmp/age-key.txt` but SOPS needs the `SOPS_AGE_KEY_FILE` environment variable to find it.

Error from previous run:
```
SOPS decryption failed: Error getting data key: 0 successful groups required, got 0
```

## Test plan
- [ ] Merge and manually trigger workflow to verify transform hooks succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)