### PR TITLE
fix: redirect debug output to stderr in talos-embed-config hook

### DIFF
--- a/images/hooks/talos-embed-config.sh
+++ b/images/hooks/talos-embed-config.sh
@@ -94,12 +94,12 @@ get_talos_version() {
 
 # Generate machine configuration using talhelper
 generate_config() {
-    echo "Generating machine configuration..."
+    echo "Generating machine configuration..." >&2
 
     cd "${TALOS_DIR}"
 
     # Generate configs to work directory
-    talhelper genconfig --out-dir "${WORK_DIR}/clusterconfig"
+    talhelper genconfig --out-dir "${WORK_DIR}/clusterconfig" >&2
 
     # Find the config file for the specified node
     local cluster_name
@@ -114,7 +114,8 @@ generate_config() {
         exit 1
     fi
 
-    echo "  Generated config: ${config_file}"
+    echo "  Generated config: ${config_file}" >&2
+    # Only the path goes to stdout for capture
     echo "${config_file}"
 }
 


### PR DESCRIPTION
## Summary
- Redirects debug messages to stderr in generate_config function
- Only the config file path is output to stdout for capture

## Context
The generate_config function was printing messages like "Generating machine configuration..." to stdout, which got captured into the `config_file` variable along with talhelper output. This caused the subsequent `cp` command to fail.

Error:
```
cp: cannot stat 'Generating machine configuration...'$'\n''generated config for cp-1...'
```

## Test plan
- [ ] Merge and manually trigger workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)