### PR TITLE
security(hooks): suppress imager output to prevent secret leakage

### DIFF
--- a/images/hooks/talos-embed-config.sh
+++ b/images/hooks/talos-embed-config.sh
@@ -135,12 +135,14 @@ embed_config() {
     # The imager creates a fresh ISO from scratch - it doesn't modify the downloaded ISO
     # Mount work dir to /out (imager's default output directory)
     # Note: --privileged is required for SELinux xattr operations on CI runners
-    docker run --rm -t --privileged \
+    # IMPORTANT: Redirect stdout to /dev/null to prevent secrets from being logged
+    # The imager prints the full profile (including embedded config with certs/keys) to stdout
+    docker run --rm --privileged \
         -v "${WORK_DIR}:/out" \
         "ghcr.io/siderolabs/imager:${talos_version}" \
         iso \
         --arch amd64 \
-        --embedded-config-path=/out/machine.yaml
+        --embedded-config-path=/out/machine.yaml > /dev/null
 
     # Find the generated ISO (imager outputs to /out/metal-amd64.iso)
     local output_iso="${WORK_DIR}/metal-amd64.iso"


### PR DESCRIPTION
## Summary
- Fix security issue where Talos imager printed full machine configuration (including certificates and private keys) to stdout
- The imager's verbose profile output was being captured in CI logs, exposing cluster secrets

## Changes
- Redirect imager stdout to `/dev/null` to suppress profile output
- Keep stderr for actual error messages
- Remove `-t` flag (TTY allocation not needed in CI)

## Important: Secret Rotation Required
**The Talos cluster secrets that were logged in previous CI runs are now compromised and should be rotated before deploying the cluster.** This can be done by regenerating `talsecret.sops.yaml` with:
```bash
cd infrastructure/compute/talos
talhelper gensecret > talsecret.sops.yaml
sops -e -i talsecret.sops.yaml
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)