### PR TITLE
feat(labctl): detect transform hook input changes in images sync

### DIFF
--- a/images/images.yaml
+++ b/images/images.yaml
@@ -41,3 +41,8 @@ spec:
             command: ./images/hooks/talos-embed-config.sh
             args: ["cp-1"]
             timeout: 10m
+            # Declare input files that affect the transform output.
+            # Changes to these files will trigger a re-sync.
+            inputs:
+              - "infrastructure/compute/talos/talconfig.yaml"
+              - "infrastructure/compute/talos/talsecret.sops.yaml"

--- a/tools/labctl/cmd/images/sync_test.go
+++ b/tools/labctl/cmd/images/sync_test.go
@@ -226,7 +226,7 @@ func TestSyncImage(t *testing.T) {
 			},
 		}
 
-		changed, err := syncImage(context.Background(), client, nil, nil, img, false, false, false, false)
+		changed, err := syncImage(context.Background(), client, nil, nil, img, t.TempDir(), false, false, false, false)
 
 		require.NoError(t, err)
 		assert.False(t, changed)
@@ -245,7 +245,7 @@ func TestSyncImage(t *testing.T) {
 			},
 		}
 
-		changed, err := syncImage(context.Background(), client, nil, nil, img, true, false, false, false)
+		changed, err := syncImage(context.Background(), client, nil, nil, img, t.TempDir(), true, false, false, false)
 
 		require.NoError(t, err)
 		assert.False(t, changed)
@@ -274,7 +274,7 @@ func TestSyncImage(t *testing.T) {
 
 		// With force=true and dryRun=true, it should show what would be done
 		// without checking checksum
-		_, err := syncImage(context.Background(), client, nil, nil, img, true, true, false, false)
+		_, err := syncImage(context.Background(), client, nil, nil, img, t.TempDir(), true, true, false, false)
 
 		require.NoError(t, err)
 		assert.False(t, checksumChecked) // Should not check checksum with force
@@ -296,7 +296,7 @@ func TestSyncImage(t *testing.T) {
 			},
 		}
 
-		_, err := syncImage(context.Background(), client, nil, nil, img, false, false, false, false)
+		_, err := syncImage(context.Background(), client, nil, nil, img, t.TempDir(), false, false, false, false)
 
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "check existing image")
@@ -322,7 +322,7 @@ func TestSyncImage(t *testing.T) {
 
 		// With noUpload=true, should skip checksum check (client is nil for noUpload)
 		// and also skip upload - this test verifies the skip behavior
-		changed, err := syncImage(context.Background(), client, nil, nil, img, true, false, false, false)
+		changed, err := syncImage(context.Background(), client, nil, nil, img, t.TempDir(), true, false, false, false)
 
 		require.NoError(t, err)
 		assert.False(t, changed)
@@ -380,7 +380,7 @@ func TestSyncImageWithHTTP(t *testing.T) {
 			},
 		}
 
-		changed, err := syncImageWithHTTP(context.Background(), client, server.Client(), nil, nil, img, false, false, false, false)
+		changed, err := syncImageWithHTTP(context.Background(), client, server.Client(), nil, nil, img, t.TempDir(), false, false, false, false)
 
 		require.NoError(t, err)
 		assert.False(t, changed) // No updateFile, so no file changes
@@ -450,7 +450,7 @@ func TestSyncImageWithHTTP(t *testing.T) {
 			},
 		}
 
-		changed, err := syncImageWithHTTP(context.Background(), client, server.Client(), nil, nil, img, false, false, false, false)
+		changed, err := syncImageWithHTTP(context.Background(), client, server.Client(), nil, nil, img, t.TempDir(), false, false, false, false)
 
 		require.NoError(t, err)
 		assert.False(t, changed)
@@ -485,7 +485,7 @@ func TestSyncImageWithHTTP(t *testing.T) {
 			},
 		}
 
-		_, err := syncImageWithHTTP(context.Background(), client, server.Client(), nil, nil, img, false, false, false, false)
+		_, err := syncImageWithHTTP(context.Background(), client, server.Client(), nil, nil, img, t.TempDir(), false, false, false, false)
 
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "download")
@@ -515,7 +515,7 @@ func TestSyncImageWithHTTP(t *testing.T) {
 			},
 		}
 
-		_, err := syncImageWithHTTP(context.Background(), client, server.Client(), nil, nil, img, false, false, false, false)
+		_, err := syncImageWithHTTP(context.Background(), client, server.Client(), nil, nil, img, t.TempDir(), false, false, false, false)
 
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "source checksum verification")
@@ -549,7 +549,7 @@ func TestSyncImageWithHTTP(t *testing.T) {
 			},
 		}
 
-		_, err := syncImageWithHTTP(context.Background(), client, server.Client(), nil, nil, img, false, false, false, false)
+		_, err := syncImageWithHTTP(context.Background(), client, server.Client(), nil, nil, img, t.TempDir(), false, false, false, false)
 
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "upload")
@@ -586,7 +586,7 @@ func TestSyncImageWithHTTP(t *testing.T) {
 			},
 		}
 
-		_, err := syncImageWithHTTP(context.Background(), client, server.Client(), nil, nil, img, false, false, false, false)
+		_, err := syncImageWithHTTP(context.Background(), client, server.Client(), nil, nil, img, t.TempDir(), false, false, false, false)
 
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "write metadata")
@@ -629,7 +629,7 @@ func TestSyncImageWithHTTP(t *testing.T) {
 			},
 		}
 
-		_, err = syncImageWithHTTP(context.Background(), client, server.Client(), nil, nil, img, false, false, false, false)
+		_, err = syncImageWithHTTP(context.Background(), client, server.Client(), nil, nil, img, t.TempDir(), false, false, false, false)
 
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "decompressed checksum verification")
@@ -677,7 +677,7 @@ func TestSyncImageWithHTTP(t *testing.T) {
 		}
 
 		// noUpload=true should download, verify, but skip upload
-		changed, err := syncImageWithHTTP(context.Background(), client, server.Client(), nil, nil, img, false, false, true, false)
+		changed, err := syncImageWithHTTP(context.Background(), client, server.Client(), nil, nil, img, t.TempDir(), false, false, true, false)
 
 		require.NoError(t, err)
 		assert.False(t, changed)
@@ -741,7 +741,7 @@ func TestSyncImageWithHTTP(t *testing.T) {
 			},
 		}
 
-		changed, err := syncImageWithHTTP(context.Background(), client, server.Client(), hookExecutor, nil, img, false, false, false, false)
+		changed, err := syncImageWithHTTP(context.Background(), client, server.Client(), hookExecutor, nil, img, dir, false, false, false, false)
 
 		require.NoError(t, err)
 		assert.False(t, changed)


### PR DESCRIPTION
## Summary

- Adds `inputs` field to transform hooks in image manifest, allowing declaration of files/globs that affect the hook's output
- Extends effective checksum calculation to incorporate a hash of declared input files
- Changes to input files now trigger re-sync even when source checksum is unchanged

Resolves HOM-30

## Test plan

- [x] Unit tests added for `EffectiveChecksumWithInputs` covering all scenarios
- [x] Existing sync tests updated to pass baseDir parameter
- [x] `just all` passes (lint, vet, tests)
- [ ] Manual testing: modify talos config files and verify sync detects the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)